### PR TITLE
fix(deps): upgrade rmcp to 2.2.0 to resolve RUSTSEC-2026-0189

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,10 +8,6 @@ ignore = [
     "RUSTSEC-2024-0388",
     # proc-macro-error2 unmaintained — transitive via matrix-sdk (vodozemac/aquamarine), no maintained alternative
     "RUSTSEC-2026-0173",
-    # RUSTSEC-2026-0189 rmcp 0.14 streamable-http SERVER DNS-rebinding — NOT reachable:
-    # PRX uses rmcp client-only (StreamableHttpClientTransport, src/tools/mcp.rs); no ServerHandler / server transport instantiated.
-    # Tracked follow-up: upgrade rmcp to >=1.4.0 (major, breaking) or drop the unused `server` feature.
-    "RUSTSEC-2026-0189",
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2004,7 +2004,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2209,7 +2209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3926,7 +3926,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.12.28",
  "ruma",
  "serde",
  "serde_html_form",
@@ -4484,7 +4484,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4572,7 +4572,7 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "slab",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4586,7 +4586,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -4680,7 +4680,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openprx"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4731,7 +4731,7 @@ dependencies = [
  "ratatui",
  "rcgen",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "rmcp",
  "rppal",
@@ -4805,7 +4805,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -4820,7 +4820,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
 ]
 
@@ -4904,12 +4904,6 @@ checksum = "1c464266693329dd5a8715098c7f86e6c5fd5d985018b8318f53d9c6c2b21a31"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "pastey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pbkdf2"
@@ -6080,9 +6074,43 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -6101,21 +6129,17 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.14.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
  "chrono",
  "futures",
  "http",
- "pastey",
  "pin-project-lite",
  "process-wrap",
- "reqwest",
- "rmcp-macros",
- "schemars",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sse-stream",
@@ -6124,19 +6148,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "rmcp-macros"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79ed92303f9262db79575aa8c3652581668e9d136be6fd0b9ededa78954c95"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -6450,7 +6461,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6558,7 +6569,6 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
- "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive",
@@ -7015,7 +7025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7036,9 +7046,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",
@@ -7241,7 +7251,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8592,6 +8602,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm_evt_listener"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9157,7 +9180,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "openprx"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors = ["g1e2x87"]
 license = "MIT OR Apache-2.0"
@@ -118,7 +118,7 @@ notify-debouncer-mini = "0.7.0"
 # Async traits
 async-trait = "0.1"
 # MCP client (stdio + streamable HTTP)
-rmcp = { version = "0.14", features = ["client", "server", "transport-child-process", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "2.2.0", default-features = false, features = ["client", "transport-child-process", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
 
 # HMAC-SHA256 (Zhipu/GLM JWT auth)
 ring = "0.17"

--- a/deny.toml
+++ b/deny.toml
@@ -22,7 +22,6 @@ ignore = [
     # proc-macro-error2 unmaintained: transitive via matrix-sdk (vodozemac → matrix-pickle-derive)
     # and aquamarine (matrix-sdk-crypto). No maintained alternative; upstream matrix-sdk tracks this.
     { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2: transitive via matrix-sdk/vodozemac, no maintained alternative, upstream matrix-sdk tracks migration" },
-    { id = "RUSTSEC-2026-0189", reason = "rmcp streamable-http SERVER DNS-rebinding — PRX uses rmcp client-only (StreamableHttpClientTransport, src/tools/mcp.rs); no server transport instantiated, unreachable. Follow-up: rmcp>=1.4.0 or drop server feature." },
 ]
 
 # ===== 许可证合规 =====

--- a/src/tools/mcp.rs
+++ b/src/tools/mcp.rs
@@ -436,6 +436,17 @@ impl McpTool {
         (!is_error, output)
     }
 
+    fn call_tool_params(
+        tool_name: &str,
+        arguments: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> CallToolRequestParams {
+        let mut params = CallToolRequestParams::new(tool_name.to_string());
+        if let Some(arguments) = arguments {
+            params = params.with_arguments(arguments);
+        }
+        params
+    }
+
     async fn discover_server_tools_stdio(
         server_name: &str,
         server: &McpServerConfig,
@@ -563,12 +574,7 @@ impl McpTool {
 
         let result = tokio::time::timeout(
             request_timeout,
-            client.call_tool(CallToolRequestParams {
-                meta: None,
-                name: tool_name.to_string().into(),
-                arguments,
-                task: None,
-            }),
+            client.call_tool(Self::call_tool_params(tool_name, arguments)),
         )
         .await
         .map_err(|_| anyhow::anyhow!("MCP call timed out after {} ms", server.request_timeout_ms))?;
@@ -629,12 +635,7 @@ impl McpTool {
 
         let result = tokio::time::timeout(
             request_timeout,
-            client.call_tool(CallToolRequestParams {
-                meta: None,
-                name: tool_name.to_string().into(),
-                arguments,
-                task: None,
-            }),
+            client.call_tool(Self::call_tool_params(tool_name, arguments)),
         )
         .await
         .map_err(|_| anyhow::anyhow!("MCP call timed out after {} ms", server.request_timeout_ms))??;


### PR DESCRIPTION
## Summary
Resolves the `RUSTSEC-2026-0189` DNS-rebinding advisory (HIGH 8.8) in rmcp's Streamable HTTP **server** transport by upgrading rmcp `0.14 -> 2.2.0` (2.2.2 is not published; 2.2.0 is the latest release).

## Why it was previously ignored (and safe)
PRX is **client-only**: `src/tools/mcp.rs` uses `().serve(transport)` + `list_all_tools`/`call_tool`/`cancel`, with no `ServerHandler` and no HTTP server transport feature enabled. The vulnerable `streamable_http_server` module was never compiled in. But `cargo audit`/`cargo deny` match on crate version, not feature reachability, so the ignore could only be dropped by moving into the patched range (`>=1.4.0`).

## Changes
- `Cargo.toml`: rmcp `0.14 -> 2.2.0`, `default-features = false` (2.2.0's defaults re-enable `server`), keeping only `client` + child-process + streamable-http-client transports.
- `src/tools/mcp.rs`: migrate the two `call_tool` sites to `CallToolRequestParams::new().with_arguments()` (2.x made the struct non-exhaustive); behavior preserved, `extract_call_success_and_output` unchanged.
- Drop the `RUSTSEC-2026-0189` ignore from `.cargo/audit.toml` and `deny.toml`.
- Bump `0.8.0 -> 0.8.1`.

## Validation
- fmt / clippy `-D warnings` / check (all-features + no-default) clean
- Full suite **5478 passed / 0 failed** (mcp 43 tests green)
- `cargo audit` + `cargo deny check advisories` no longer flag RUSTSEC-2026-0189 (resolved, not ignored)
- Real stdio MCP client E2E: `refresh -> serve -> list_all_tools -> call_tool -> extract` returns success

🤖 Generated with [Claude Code](https://claude.com/claude-code)