### PR TITLE
feat(chat): axis-separated key model + UX polish (v0.8.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,7 +4680,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openprx"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "openprx"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 authors = ["g1e2x87"]
 license = "MIT OR Apache-2.0"

--- a/src/chat/action.rs
+++ b/src/chat/action.rs
@@ -32,7 +32,7 @@ pub struct ProviderWorkerStatus {
     pub rows: Vec<ProviderWorkerStatusRow>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderWorkerStatusRow {
     pub task_id: u64,
     pub sequence: u64,
@@ -41,11 +41,12 @@ pub struct ProviderWorkerStatusRow {
     pub started_at_ms: i64,
     pub finalized_total_tokens: Option<u64>,
     pub completion_ready: bool,
+    pub recent_tool_call: Option<String>,
 }
 
 impl ProviderWorkerStatusRow {
     #[must_use]
-    pub const fn is_active(self) -> bool {
+    pub const fn is_active(&self) -> bool {
         matches!(
             self.state,
             ProviderWorkerRowState::Running
@@ -88,7 +89,7 @@ pub fn build_provider_worker_active_view_with_io(
     scroll_offset: usize,
     io_lines: Vec<String>,
 ) -> crate::chat::sessions::ActiveSessionView {
-    let row = status.rows.iter().find(|row| row.sequence == sequence).copied();
+    let row = status.rows.iter().find(|row| row.sequence == sequence);
     let title = format!("main provider w#{sequence}");
     let mut lines = Vec::new();
     if let Some(row) = row {
@@ -674,6 +675,7 @@ mod tests {
                 started_at_ms: 0,
                 finalized_total_tokens: None,
                 completion_ready: false,
+                recent_tool_call: None,
             }],
         }
     }

--- a/src/chat/action.rs
+++ b/src/chat/action.rs
@@ -554,9 +554,6 @@ pub enum Action {
     SwitcherMoved { selected: usize },
     /// 关闭 switcher 弹层（v1.1b）。reducer 写入 `ui.switcher = None`。
     SwitcherClosed,
-    /// UI-only bottom strip selection changed. This is intentionally separate
-    /// from `SessionFocusChanged`; it highlights a row but does not route input.
-    StripSelectionChanged { selected: Option<u64> },
     /// P7c: open the saved chat-session history picker. Distinct from the
     /// child-TUI Ctrl+G switcher.
     SavedSessionPickerOpened {
@@ -643,7 +640,6 @@ impl Action {
             Self::SwitcherOpened { .. } => "SwitcherOpened",
             Self::SwitcherMoved { .. } => "SwitcherMoved",
             Self::SwitcherClosed => "SwitcherClosed",
-            Self::StripSelectionChanged { .. } => "StripSelectionChanged",
             Self::SavedSessionPickerOpened { .. } => "SavedSessionPickerOpened",
             Self::SavedSessionPickerMoved { .. } => "SavedSessionPickerMoved",
             Self::SavedSessionPickerClosed => "SavedSessionPickerClosed",

--- a/src/chat/dispatcher.rs
+++ b/src/chat/dispatcher.rs
@@ -1275,6 +1275,7 @@ impl EffectExecutor {
                                     tool_id,
                                     name,
                                     args,
+                                    selected_approval: false,
                                 });
                                 state.focus = crate::chat::sessions::FocusTarget::Approval;
                                 state.switcher = None;
@@ -10060,6 +10061,7 @@ mod real_mode_tests {
                                                 tool_id: tool_id.clone(),
                                                 name: name.clone(),
                                                 args: args.clone(),
+                                                selected_approval: false,
                                             });
                                         let decision = crate::chat::tui::dispatch_global_key(
                                             crossterm::event::KeyEvent::new(

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -109,6 +109,8 @@ use std::io::{IsTerminal as _, Write as _};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+#[cfg(feature = "terminal-tui")]
+use std::time::Instant;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -1276,18 +1278,8 @@ fn compact_child_completion_summary(text: &str) -> String {
 }
 
 #[cfg(feature = "terminal-tui")]
-fn refresh_sessions_cache_and_clear_stale_strip_selection(
-    mirror: &mut tui::TuiState,
-    entries: Vec<crate::chat::sessions::SwitcherEntry>,
-) -> bool {
-    let stale_strip_selection = mirror
-        .strip_selection
-        .is_some_and(|selected| !entries.iter().any(|entry| entry.seq == selected));
+fn refresh_sessions_cache(mirror: &mut tui::TuiState, entries: Vec<crate::chat::sessions::SwitcherEntry>) {
     mirror.sessions_cache = entries;
-    if stale_strip_selection {
-        mirror.strip_selection = None;
-    }
-    stale_strip_selection
 }
 
 fn is_useful_completion_line(line: &str) -> bool {
@@ -1566,6 +1558,42 @@ mod session_cleanup_tests {
 const MOUSE_WHEEL_TRANSCRIPT_ROWS: usize = 3;
 
 #[cfg(feature = "terminal-tui")]
+const DIRECTIONAL_SWITCH_DEBOUNCE: Duration = Duration::from_millis(100);
+
+#[cfg(feature = "terminal-tui")]
+fn debounce_directional_switch_dispatch(
+    key: crossterm::event::KeyEvent,
+    dispatch: tui::KeyDispatch,
+    last_directional_switch_at: &mut Option<Instant>,
+    now: Instant,
+) -> tui::KeyDispatch {
+    if key.modifiers == crossterm::event::KeyModifiers::NONE
+        && matches!(
+            key.code,
+            crossterm::event::KeyCode::Left | crossterm::event::KeyCode::Right
+        )
+        && matches!(
+            &dispatch,
+            tui::KeyDispatch::AttachSession { .. }
+                | tui::KeyDispatch::SwitchSession { .. }
+                | tui::KeyDispatch::OpenProviderWorkerView { .. }
+                | tui::KeyDispatch::CloseProviderWorkerView
+                | tui::KeyDispatch::RequestDetach
+        )
+    {
+        if last_directional_switch_at.is_some_and(|previous| now.duration_since(previous) < DIRECTIONAL_SWITCH_DEBOUNCE)
+        {
+            tui::KeyDispatch::Consumed
+        } else {
+            *last_directional_switch_at = Some(now);
+            dispatch
+        }
+    } else {
+        dispatch
+    }
+}
+
+#[cfg(feature = "terminal-tui")]
 fn apply_fullscreen_mouse_scroll(
     kind: crossterm::event::MouseEventKind,
     fullscreen_scroll: &mut tui::FullscreenTranscriptScroll,
@@ -1781,34 +1809,14 @@ mod runtime_display_tests {
 
     #[cfg(feature = "terminal-tui")]
     #[test]
-    fn sessions_tick_helper_clears_reaped_strip_selection() {
+    fn sessions_tick_helper_refreshes_session_cache() {
         let mut mirror = tui::TuiState::new("provider", "model");
-        mirror.strip_selection = Some(9);
 
-        let stale = refresh_sessions_cache_and_clear_stale_strip_selection(&mut mirror, vec![switcher_entry(1)]);
+        refresh_sessions_cache(&mut mirror, vec![switcher_entry(1), switcher_entry(2)]);
 
-        assert!(
-            stale,
-            "missing selected seq should request StripSelectionChanged dispatch"
-        );
-        assert_eq!(mirror.strip_selection, None);
-        assert_eq!(mirror.sessions_cache.len(), 1);
+        assert_eq!(mirror.sessions_cache.len(), 2);
         assert_eq!(mirror.sessions_cache.first().map(|entry| entry.seq), Some(1));
-    }
-
-    #[cfg(feature = "terminal-tui")]
-    #[test]
-    fn sessions_tick_helper_keeps_live_strip_selection() {
-        let mut mirror = tui::TuiState::new("provider", "model");
-        mirror.strip_selection = Some(2);
-
-        let stale = refresh_sessions_cache_and_clear_stale_strip_selection(
-            &mut mirror,
-            vec![switcher_entry(1), switcher_entry(2)],
-        );
-
-        assert!(!stale);
-        assert_eq!(mirror.strip_selection, Some(2));
+        assert_eq!(mirror.sessions_cache.get(1).map(|entry| entry.seq), Some(2));
     }
 
     #[test]
@@ -2593,12 +2601,19 @@ fn log_redux_key_diff(old: &tui::KeyDispatch, new_effects: &[state::Effect]) {
         tui::KeyDispatch::SavedSessionPickerClosed => "SavedSessionPickerClosed",
         tui::KeyDispatch::ResumeSavedSession { .. } => "ResumeSavedSession",
         tui::KeyDispatch::AttachSession { .. } => "AttachSession",
-        tui::KeyDispatch::StripSelectionChanged { .. } => "StripSelectionChanged",
         tui::KeyDispatch::RequestDetach => "RequestDetach",
+        tui::KeyDispatch::ScrollTranscriptUp => "ScrollTranscriptUp",
+        tui::KeyDispatch::ScrollTranscriptDown => "ScrollTranscriptDown",
+        tui::KeyDispatch::PageTranscriptUp => "PageTranscriptUp",
+        tui::KeyDispatch::PageTranscriptDown => "PageTranscriptDown",
+        tui::KeyDispatch::TranscriptHome => "TranscriptHome",
+        tui::KeyDispatch::TranscriptEnd => "TranscriptEnd",
         tui::KeyDispatch::ScrollSessionUp => "ScrollSessionUp",
         tui::KeyDispatch::ScrollSessionDown => "ScrollSessionDown",
         tui::KeyDispatch::PageSessionUp => "PageSessionUp",
         tui::KeyDispatch::PageSessionDown => "PageSessionDown",
+        tui::KeyDispatch::SessionHome => "SessionHome",
+        tui::KeyDispatch::SessionEnd => "SessionEnd",
         tui::KeyDispatch::SwitchSession { .. } => "SwitchSession",
         tui::KeyDispatch::OpenTranscriptViewer => "OpenTranscriptViewer",
         tui::KeyDispatch::CloseTranscriptViewer => "CloseTranscriptViewer",
@@ -2654,12 +2669,19 @@ fn log_redux_key_diff(old: &tui::KeyDispatch, new_effects: &[state::Effect]) {
         | tui::KeyDispatch::SavedSessionPickerClosed
         | tui::KeyDispatch::ResumeSavedSession { .. }
         | tui::KeyDispatch::AttachSession { .. }
-        | tui::KeyDispatch::StripSelectionChanged { .. }
         | tui::KeyDispatch::RequestDetach
+        | tui::KeyDispatch::ScrollTranscriptUp
+        | tui::KeyDispatch::ScrollTranscriptDown
+        | tui::KeyDispatch::PageTranscriptUp
+        | tui::KeyDispatch::PageTranscriptDown
+        | tui::KeyDispatch::TranscriptHome
+        | tui::KeyDispatch::TranscriptEnd
         | tui::KeyDispatch::ScrollSessionUp
         | tui::KeyDispatch::ScrollSessionDown
         | tui::KeyDispatch::PageSessionUp
         | tui::KeyDispatch::PageSessionDown
+        | tui::KeyDispatch::SessionHome
+        | tui::KeyDispatch::SessionEnd
         | tui::KeyDispatch::SwitchSession { .. }
         | tui::KeyDispatch::OpenTranscriptViewer
         | tui::KeyDispatch::CloseTranscriptViewer
@@ -4747,15 +4769,9 @@ pub async fn run(
                     for entry in &mut entries {
                         entry.idle_warning = idle_warnings.contains(&entry.seq);
                     }
-                    let stale_strip_selection = {
+                    {
                         let mut mirror = chat_mirror.lock();
-                        refresh_sessions_cache_and_clear_stale_strip_selection(&mut mirror, entries.clone())
-                    };
-                    if stale_strip_selection {
-                        let _ = chat_dispatcher.dispatch_or_log(
-                            crate::chat::action::Action::StripSelectionChanged { selected: None },
-                            "chat.strip_selection_reaped",
-                        );
+                        refresh_sessions_cache(&mut mirror, entries.clone());
                     }
                     if entries != last_sessions_entries {
                         last_sessions_entries = entries.clone();
@@ -6004,15 +6020,10 @@ Retry with a compatible model: /provider {new_provider} <model>"
                                     crate::chat::action::Action::SessionFocusChanged { focus: prev_focus },
                                     "chat.session_focus_attach_pty_done",
                                 );
-                                let _ = chat_dispatcher.dispatch_or_log(
-                                    crate::chat::action::Action::StripSelectionChanged { selected: None },
-                                    "chat.strip_selection_attach_pty_done",
-                                );
                                 {
                                     let mut mirror = chat_mirror.lock();
                                     mirror.focus = prev_focus;
                                     mirror.active_session_view = None;
-                                    mirror.strip_selection = None;
                                 }
                                 let _ = chat_dispatcher.dispatch_or_log(
                                     crate::chat::action::Action::ActiveSessionViewUpdated { view: None },
@@ -6080,17 +6091,12 @@ Retry with a compatible model: /provider {new_provider} <model>"
                                         crate::chat::action::Action::SessionFocusChanged { focus },
                                         "chat.session_focus_attach",
                                     );
-                                    let _ = chat_dispatcher.dispatch_or_log(
-                                        crate::chat::action::Action::StripSelectionChanged { selected: None },
-                                        "chat.strip_selection_attach",
-                                    );
                                     #[cfg(feature = "terminal-tui")]
                                     {
                                         {
                                             let mut mirror = chat_mirror.lock();
                                             mirror.focus = focus;
                                             mirror.active_session_view = Some(active_projection.view.clone());
-                                            mirror.strip_selection = None;
                                         }
                                         let _ = chat_dispatcher.dispatch_or_log(
                                             crate::chat::action::Action::ActiveSessionViewUpdated {
@@ -11333,7 +11339,6 @@ fn open_provider_worker_view(
         );
         let focus = crate::chat::sessions::FocusTarget::Worker { sequence };
         guard.focus = focus;
-        guard.strip_selection = None;
         guard.active_session_view = Some(view.clone());
         (view, focus)
     };
@@ -11371,7 +11376,6 @@ fn close_provider_worker_view(
             return;
         }
         guard.focus = crate::chat::sessions::FocusTarget::Main;
-        guard.strip_selection = None;
         guard.active_session_view = None;
     }
     let _ = chat_dispatcher.dispatch_or_log(
@@ -11832,6 +11836,7 @@ fn run_tui_unified_loop(
 
     let mut terminal = new_fullscreen_terminal()?;
     let mut fullscreen_scroll = tui::FullscreenTranscriptScroll::default();
+    let mut last_directional_switch_at: Option<Instant> = None;
 
     terminal
         .draw(|f| {
@@ -11994,37 +11999,17 @@ fn run_tui_unified_loop(
                         continue;
                     }
                 }
-                if key.modifiers == crossterm::event::KeyModifiers::NONE
-                    && matches!(
-                        key.code,
-                        crossterm::event::KeyCode::PageUp
-                            | crossterm::event::KeyCode::PageDown
-                            | crossterm::event::KeyCode::Home
-                            | crossterm::event::KeyCode::End
-                    )
-                {
-                    let scroll_available =
-                        render_source.with_view(|view| tui::fullscreen_transcript_scroll_available(view));
-                    if scroll_available {
-                        let total_height = terminal.size().map(|s| s.height).unwrap_or(24);
-                        let page_rows =
-                            render_source.with_view(|view| tui::fullscreen_transcript_page_rows(view, total_height));
-                        match key.code {
-                            crossterm::event::KeyCode::PageUp => fullscreen_scroll.page_up(page_rows),
-                            crossterm::event::KeyCode::PageDown => fullscreen_scroll.page_down(page_rows),
-                            crossterm::event::KeyCode::Home => fullscreen_scroll.jump_top(),
-                            crossterm::event::KeyCode::End => fullscreen_scroll.jump_bottom(),
-                            _ => {}
-                        }
-                        let _ = redraw_tx.try_send(());
-                        continue;
-                    }
-                }
                 let _ = chat_dispatcher.dispatch_or_log(Action::KeyPressed(key), "chat.tui_key_pressed");
 
                 sync_key_mirror_observation_state(&render_source, &mirror);
                 let switcher_open_before_dispatch = mirror.lock().switcher.is_some();
-                let dispatch = tui::dispatch_global_key(key, &mut mirror.lock());
+                let mut dispatch = tui::dispatch_global_key(key, &mut mirror.lock());
+                dispatch = debounce_directional_switch_dispatch(
+                    key,
+                    dispatch,
+                    &mut last_directional_switch_at,
+                    Instant::now(),
+                );
                 if !(key.code == crossterm::event::KeyCode::Esc
                     && key.modifiers == crossterm::event::KeyModifiers::NONE)
                 {
@@ -12210,12 +12195,6 @@ fn run_tui_unified_loop(
                             return Ok(());
                         }
                     }
-                    tui::KeyDispatch::StripSelectionChanged { selected } => {
-                        let _ = chat_dispatcher.dispatch_or_log(
-                            crate::chat::action::Action::StripSelectionChanged { selected },
-                            "chat.strip_selection_changed",
-                        );
-                    }
                     tui::KeyDispatch::SwitchSession { seq } => {
                         // P3: directional child-session switching reuses the
                         // exact same attach owner as Ctrl+G Enter. The key
@@ -12321,6 +12300,36 @@ fn run_tui_unified_loop(
                             return Ok(());
                         }
                     }
+                    tui::KeyDispatch::ScrollTranscriptUp => {
+                        fullscreen_scroll.line_up();
+                        let _ = redraw_tx.try_send(());
+                    }
+                    tui::KeyDispatch::ScrollTranscriptDown => {
+                        fullscreen_scroll.line_down();
+                        let _ = redraw_tx.try_send(());
+                    }
+                    tui::KeyDispatch::PageTranscriptUp => {
+                        let total_height = terminal.size().map(|s| s.height).unwrap_or(24);
+                        let page_rows =
+                            render_source.with_view(|view| tui::fullscreen_transcript_page_rows(view, total_height));
+                        fullscreen_scroll.page_up(page_rows);
+                        let _ = redraw_tx.try_send(());
+                    }
+                    tui::KeyDispatch::PageTranscriptDown => {
+                        let total_height = terminal.size().map(|s| s.height).unwrap_or(24);
+                        let page_rows =
+                            render_source.with_view(|view| tui::fullscreen_transcript_page_rows(view, total_height));
+                        fullscreen_scroll.page_down(page_rows);
+                        let _ = redraw_tx.try_send(());
+                    }
+                    tui::KeyDispatch::TranscriptHome => {
+                        fullscreen_scroll.jump_top();
+                        let _ = redraw_tx.try_send(());
+                    }
+                    tui::KeyDispatch::TranscriptEnd => {
+                        fullscreen_scroll.jump_bottom();
+                        let _ = redraw_tx.try_send(());
+                    }
                     tui::KeyDispatch::ScrollSessionUp => {
                         scroll_active_session_view(&mirror, chat_dispatcher, &redraw_tx, 1, true);
                     }
@@ -12344,6 +12353,12 @@ fn run_tui_unified_loop(
                             usize::from(tui::ACTIVE_SESSION_VIEW_DESIRED_ROWS),
                             false,
                         );
+                    }
+                    tui::KeyDispatch::SessionHome => {
+                        scroll_active_session_view(&mirror, chat_dispatcher, &redraw_tx, usize::MAX, true);
+                    }
+                    tui::KeyDispatch::SessionEnd => {
+                        scroll_active_session_view(&mirror, chat_dispatcher, &redraw_tx, usize::MAX, false);
                     }
                     tui::KeyDispatch::Cancelled => {
                         let _ = chat_dispatcher
@@ -15584,6 +15599,38 @@ mod p6b2_external_editor_tests {
         );
 
         CHAT_KEYBOARD_ENHANCEMENT_ACTIVE.store(previous, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn directional_switch_debounce_suppresses_rapid_attach_dispatches() {
+        let key =
+            crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Right, crossterm::event::KeyModifiers::NONE);
+        let start = Instant::now();
+        let mut last = None;
+
+        assert_eq!(
+            debounce_directional_switch_dispatch(key, tui::KeyDispatch::AttachSession { seq: 1 }, &mut last, start,),
+            tui::KeyDispatch::AttachSession { seq: 1 }
+        );
+        assert_eq!(
+            debounce_directional_switch_dispatch(
+                key,
+                tui::KeyDispatch::SwitchSession { seq: 2 },
+                &mut last,
+                start + Duration::from_millis(20),
+            ),
+            tui::KeyDispatch::Consumed,
+            "rapid Left/Right repeats must not enqueue another synthetic attach"
+        );
+        assert_eq!(
+            debounce_directional_switch_dispatch(
+                key,
+                tui::KeyDispatch::SwitchSession { seq: 2 },
+                &mut last,
+                start + Duration::from_millis(120),
+            ),
+            tui::KeyDispatch::SwitchSession { seq: 2 }
+        );
     }
 }
 

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -8771,6 +8771,7 @@ fn provider_worker_status(
                 started_at_ms: worker.started_at_ms,
                 finalized_total_tokens: worker.finalized_total_tokens,
                 completion_ready: worker.completion_ready,
+                recent_tool_call: None,
             });
         }
         match worker.state {
@@ -11841,11 +11842,13 @@ fn run_tui_unified_loop(
         .map_err(|e| anyhow::anyhow!("initial TUI draw failed: {e}"))?;
 
     let mut skip_next_draw = false;
+    let mut deferred_redraw_requested = false;
     let mut pending_events = VecDeque::new();
 
-    // 50 ms event poll → ~20 fps idle redraw cap. Streaming wakes via
-    // `redraw_rx` so this is just a floor, not an upper bound.
-    let poll = Duration::from_millis(50);
+    // 150 ms only while an on-screen animation is active. Idle mode uses a long
+    // poll so a completed/empty TUI does not keep a fixed redraw/tick cadence.
+    let active_animation_poll = Duration::from_millis(150);
+    let idle_poll = Duration::from_millis(1_000);
 
     loop {
         if shutdown.is_cancelled() {
@@ -11877,6 +11880,7 @@ fn run_tui_unified_loop(
                 tracing::warn!(error = %e, "post-PTY terminal clear failed");
             }
             skip_next_draw = false;
+            deferred_redraw_requested = true;
         }
 
         // ── 1. Drain coalesced redraw wakeups, then redraw fullscreen frame ─
@@ -11884,20 +11888,32 @@ fn run_tui_unified_loop(
         while redraw_rx.try_recv().is_ok() {
             redraw_requested = true;
         }
+        redraw_requested |= deferred_redraw_requested;
+        deferred_redraw_requested = false;
+        let periodic_redraw_active = render_source.with_view(|view| tui::periodic_redraw_active_for_view(view))
+            || mirror.lock().periodic_redraw_active();
         if skip_next_draw && !redraw_requested {
             skip_next_draw = false;
-        } else if let Err(e) = terminal.draw(|f| {
-            render_source.with_view(|view| {
-                tui::render_fullscreen_chat(f, view, &mut fullscreen_scroll);
-            });
-        }) {
-            tracing::warn!(error = %e, "TUI draw failed");
+            deferred_redraw_requested = true;
+        } else if redraw_requested || periodic_redraw_active {
+            if let Err(e) = terminal.draw(|f| {
+                render_source.with_view(|view| {
+                    tui::render_fullscreen_chat(f, view, &mut fullscreen_scroll);
+                });
+            }) {
+                tracing::warn!(error = %e, "TUI draw failed");
+            }
         }
 
         // ── 2. Wait for the next input event, with a 50 ms floor ──────
         let ev = if let Some(ev) = pending_events.pop_front() {
             ev
         } else {
+            let poll = if periodic_redraw_active {
+                active_animation_poll
+            } else {
+                idle_poll
+            };
             if !crossterm::event::poll(poll)? {
                 continue;
             }
@@ -14911,6 +14927,7 @@ mod s4_a_4 {
                 started_at_ms: chrono::Utc::now().timestamp_millis(),
                 finalized_total_tokens: None,
                 completion_ready: false,
+                recent_tool_call: None,
             }],
         };
         let snap = Arc::new(state.build_ui_snapshot(1));
@@ -14948,6 +14965,7 @@ mod s4_a_4 {
                     started_at_ms: 0,
                     finalized_total_tokens: None,
                     completion_ready: false,
+                    recent_tool_call: None,
                 },
                 crate::chat::action::ProviderWorkerStatusRow {
                     task_id: 20,
@@ -14957,6 +14975,7 @@ mod s4_a_4 {
                     started_at_ms: 0,
                     finalized_total_tokens: None,
                     completion_ready: false,
+                    recent_tool_call: None,
                 },
             ],
         };
@@ -16264,6 +16283,7 @@ mod p3_directional_switch_tests {
                     started_at_ms: chrono::Utc::now().timestamp_millis().saturating_sub(1_000),
                     finalized_total_tokens: None,
                     completion_ready: false,
+                    recent_tool_call: None,
                 },
                 crate::chat::action::ProviderWorkerStatusRow {
                     task_id: 2,
@@ -16273,6 +16293,7 @@ mod p3_directional_switch_tests {
                     started_at_ms: chrono::Utc::now().timestamp_millis().saturating_sub(9_000),
                     finalized_total_tokens: Some(1_250),
                     completion_ready: true,
+                    recent_tool_call: None,
                 },
             ],
         };
@@ -18866,6 +18887,7 @@ mod regfix_approval_switch_tests {
                 tool_id: "tool-live".to_string(),
                 name: "shell".to_string(),
                 args: "{}".to_string(),
+                selected_approval: false,
             });
             mirror.context_used_tokens = Some(2_500);
             mirror.context_window_tokens = Some(10_000_000);

--- a/src/chat/sessions/focus.rs
+++ b/src/chat/sessions/focus.rs
@@ -94,6 +94,9 @@ pub struct PendingToolApprovalView {
     pub tool_id: String,
     pub name: String,
     pub args: String,
+    /// True selects Approve, false selects Deny. The default is deny so Enter
+    /// never approves a tool before the operator moves the selection.
+    pub selected_approval: bool,
 }
 
 /// One row in the Ctrl+G session switcher. A plain display snapshot (no async,

--- a/src/chat/state.rs
+++ b/src/chat/state.rs
@@ -341,9 +341,6 @@ pub struct UiState {
     /// Ctrl+G session switcher 弹层状态（v1.1b），关闭时为 `None`。由 key 线程
     /// 经 `Action::SwitcherOpened` / `SwitcherMoved` / `SwitcherClosed` 写入。
     pub switcher: Option<crate::chat::sessions::SwitcherState>,
-    /// UI-only bottom-strip selection for direct Alt+arrow navigation. Separate
-    /// from `focus`: this highlights an entry but does not route input there.
-    pub strip_selection: Option<u64>,
     /// Slash-command menu overlay. Derived from the current input command token.
     pub slash_menu: Option<SlashMenuState>,
     /// Security-filtered `@path` completion source, delivered via Action.
@@ -415,8 +412,6 @@ pub struct UiSnapshot {
     pub focus: crate::chat::sessions::FocusTarget,
     /// Ctrl+G switcher 弹层（v1.1b），`None` 表示关闭。renderer 据此画弹层。
     pub switcher: Option<crate::chat::sessions::SwitcherState>,
-    /// UI-only bottom-strip selection. `None` means no highlighted strip entry.
-    pub strip_selection: Option<u64>,
     /// Slash-command menu overlay.
     pub slash_menu: Option<SlashMenuState>,
     /// P7c saved chat-session history picker overlay.
@@ -454,7 +449,6 @@ impl UiSnapshot {
             token_usage_summary: MainSessionTokenUsageSummary::default(),
             focus: crate::chat::sessions::FocusTarget::Main,
             switcher: None,
-            strip_selection: None,
             slash_menu: None,
             saved_session_picker: None,
         }
@@ -816,7 +810,6 @@ impl ChatState {
                 token_usage_summary: MainSessionTokenUsageSummary::default(),
                 focus: crate::chat::sessions::FocusTarget::Main,
                 switcher: None,
-                strip_selection: None,
                 slash_menu: None,
                 at_path_candidates: Vec::new(),
                 saved_session_picker: None,
@@ -910,7 +903,6 @@ impl ChatState {
             token_usage_summary: self.ui.token_usage_summary,
             focus: self.ui.focus,
             switcher: self.ui.switcher.clone(),
-            strip_selection: self.ui.strip_selection,
             slash_menu: self.ui.slash_menu.clone(),
             saved_session_picker: self.ui.saved_session_picker.clone(),
         }
@@ -1157,7 +1149,6 @@ impl ChatState {
             Action::SwitcherOpened { entries } => self.reduce_switcher_opened(entries),
             Action::SwitcherMoved { selected } => self.reduce_switcher_moved(selected),
             Action::SwitcherClosed => self.reduce_switcher_closed(),
-            Action::StripSelectionChanged { selected } => self.reduce_strip_selection_changed(selected),
             Action::SavedSessionPickerOpened { entries } => self.reduce_saved_session_picker_opened(entries),
             Action::SavedSessionPickerMoved { selected } => self.reduce_saved_session_picker_moved(selected),
             Action::SavedSessionPickerClosed => self.reduce_saved_session_picker_closed(),
@@ -1203,9 +1194,6 @@ impl ChatState {
             }
             return vec![Effect::RequestRedraw];
         }
-        if key.code == KeyCode::Esc && key.modifiers == KeyModifiers::NONE && self.ui.strip_selection.take().is_some() {
-            return vec![Effect::RequestRedraw];
-        }
         if self.ui.pending_tool_approval.is_some()
             || matches!(self.ui.focus, crate::chat::sessions::FocusTarget::Approval)
         {
@@ -1232,43 +1220,6 @@ impl ChatState {
                 crate::chat::tui::KeyDispatch::Ignored => Vec::new(),
                 _ => vec![Effect::RequestRedraw],
             };
-        }
-
-        if key.modifiers == KeyModifiers::ALT {
-            let direction = match key.code {
-                KeyCode::Left | KeyCode::Up => Some(crate::chat::sessions::SessionDirection::Previous),
-                KeyCode::Right | KeyCode::Down => Some(crate::chat::sessions::SessionDirection::Next),
-                _ => None,
-            };
-            if let Some(direction) = direction {
-                self.ui.strip_selection = crate::chat::tui::move_strip_selection(
-                    &self.ui.sessions_entries,
-                    self.ui.strip_selection,
-                    self.ui.focus,
-                    direction,
-                );
-                return vec![Effect::RequestRedraw];
-            }
-            if key.code == KeyCode::Enter
-                && let Some(selected) = self.ui.strip_selection
-            {
-                if crate::chat::tui::selected_strip_entry(&self.ui.sessions_entries, Some(selected)).is_some() {
-                    return vec![
-                        Effect::LogTrace {
-                            level: tracing::Level::DEBUG,
-                            msg: format!("strip_alt_enter_attach seq={selected}"),
-                        },
-                        Effect::RequestRedraw,
-                    ];
-                }
-                self.ui.strip_selection = None;
-                self.ui
-                    .conversation_lines
-                    .push(crate::chat::tui::ConversationLine::System {
-                        content: "session gone".to_string(),
-                    });
-                return vec![Effect::RequestRedraw];
-            }
         }
 
         if key.code == KeyCode::Esc && key.modifiers == KeyModifiers::NONE && self.control.generating {
@@ -3053,16 +3004,6 @@ impl ChatState {
         vec![Effect::RequestRedraw]
     }
 
-    /// `Action::StripSelectionChanged` — update the UI-only bottom-strip
-    /// highlight without changing input-routing focus.
-    fn reduce_strip_selection_changed(&mut self, selected: Option<u64>) -> Vec<Effect> {
-        if self.ui.strip_selection == selected {
-            return Vec::new();
-        }
-        self.ui.strip_selection = selected;
-        vec![Effect::RequestRedraw]
-    }
-
     /// `Action::SavedSessionPickerOpened` (P7c) — open the saved chat-session
     /// history picker, separate from the child-TUI Ctrl+G switcher.
     fn reduce_saved_session_picker_opened(
@@ -3414,7 +3355,6 @@ const fn ui_dirty_for(action: &Action) -> bool {
         | Action::SwitcherOpened { .. }
         | Action::SwitcherMoved { .. }
         | Action::SwitcherClosed
-        | Action::StripSelectionChanged { .. }
         | Action::SavedSessionPickerOpened { .. }
         | Action::SavedSessionPickerMoved { .. }
         | Action::SavedSessionPickerClosed => true,
@@ -3937,32 +3877,7 @@ mod tests {
 
     #[cfg(feature = "terminal-tui")]
     #[test]
-    fn strip_selection_changed_writes_snapshot_without_focus_change() {
-        let mut state = make_state();
-        state.ui.focus = crate::chat::sessions::FocusTarget::Session { seq: 1 };
-
-        let effects = state.reduce(Action::StripSelectionChanged { selected: Some(2) });
-
-        assert!(matches!(effects.as_slice(), [Effect::RequestRedraw]));
-        assert_eq!(state.ui.strip_selection, Some(2));
-        assert_eq!(
-            state.ui.focus,
-            crate::chat::sessions::FocusTarget::Session { seq: 1 },
-            "strip selection is not input routing focus"
-        );
-        assert_eq!(state.build_ui_snapshot(1).strip_selection, Some(2));
-
-        let effects = state.reduce(Action::StripSelectionChanged { selected: Some(2) });
-        assert!(effects.is_empty(), "unchanged strip selection is a reducer no-op");
-
-        let effects = state.reduce(Action::StripSelectionChanged { selected: None });
-        assert!(matches!(effects.as_slice(), [Effect::RequestRedraw]));
-        assert_eq!(state.ui.strip_selection, None);
-    }
-
-    #[cfg(feature = "terminal-tui")]
-    #[test]
-    fn alt_enter_stale_strip_selection_clears_and_surfaces_session_gone() {
+    fn alt_enter_no_longer_surfaces_session_gone() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
         let mut state = make_state();
@@ -3977,30 +3892,22 @@ mod tests {
             token_usage_records: Vec::new(),
             idle_warning: false,
         }];
-        state.ui.strip_selection = Some(2);
         state.ui.input.set_text("draft");
 
         let effects = state.reduce(Action::KeyPressed(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT)));
 
         assert!(matches!(effects.as_slice(), [Effect::RequestRedraw]));
-        assert_eq!(state.ui.strip_selection, None);
         assert_eq!(
             state.ui.input.text(),
-            "draft",
-            "stale Alt+Enter must not insert a newline"
+            "draft\n",
+            "Alt+Enter is only an input newline chord"
         );
-        assert!(
-            matches!(
-                state.ui.conversation_lines.last(),
-                Some(crate::chat::tui::ConversationLine::System { content }) if content == "session gone"
-            ),
-            "reducer should surface session gone"
-        );
+        assert!(state.ui.conversation_lines.is_empty());
     }
 
     #[cfg(feature = "terminal-tui")]
     #[test]
-    fn alt_enter_matching_strip_selection_uses_attach_branch_without_newline() {
+    fn alt_enter_with_sessions_no_longer_uses_attach_branch() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
         let mut state = make_state();
@@ -4015,29 +3922,21 @@ mod tests {
             token_usage_records: Vec::new(),
             idle_warning: false,
         }];
-        state.ui.strip_selection = Some(2);
         state.ui.input.set_text("draft");
 
         let effects = state.reduce(Action::KeyPressed(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT)));
 
-        assert!(
-            matches!(
-                effects.as_slice(),
-                [Effect::LogTrace { msg, .. }, Effect::RequestRedraw] if msg.contains("strip_alt_enter_attach seq=2")
-            ),
-            "matching Alt+Enter should take attach branch: {effects:?}"
-        );
-        assert_eq!(state.ui.strip_selection, Some(2));
+        assert!(matches!(effects.as_slice(), [Effect::RequestRedraw]));
         assert_eq!(
             state.ui.input.text(),
-            "draft",
-            "matching Alt+Enter must not insert a newline"
+            "draft\n",
+            "matching Alt+Enter no longer attaches strip selection"
         );
     }
 
     #[cfg(feature = "terminal-tui")]
     #[test]
-    fn alt_enter_without_strip_selection_falls_through_to_newline_insert() {
+    fn alt_enter_falls_through_to_newline_insert() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
         let mut state = make_state();
@@ -4060,7 +3959,7 @@ mod tests {
 
     #[cfg(feature = "terminal-tui")]
     #[test]
-    fn slash_menu_captures_alt_arrows_before_strip_selection() {
+    fn slash_menu_captures_alt_arrows_before_bottom_navigation() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
         let mut state = make_state();
@@ -4090,7 +3989,6 @@ mod tests {
         ];
         state.ui.input.set_text("/mo");
         state.ui.slash_menu = Some(SlashMenuState::new("mo"));
-        state.ui.strip_selection = Some(2);
 
         let effects = state.reduce(Action::KeyPressed(KeyEvent::new(KeyCode::Up, KeyModifiers::ALT)));
 
@@ -4098,17 +3996,12 @@ mod tests {
             effects.iter().all(|effect| matches!(effect, Effect::RequestRedraw)),
             "slash menu may redraw, but must not leak Alt+Up into strip navigation: {effects:?}"
         );
-        assert_eq!(
-            state.ui.strip_selection,
-            Some(2),
-            "Alt+Up must not move the session strip while slash menu is open"
-        );
         assert!(state.ui.slash_menu.is_some(), "slash menu remains open");
     }
 
     #[cfg(feature = "terminal-tui")]
     #[test]
-    fn saved_session_picker_captures_alt_enter_before_stale_strip_selection() {
+    fn saved_session_picker_captures_alt_enter_before_input_newline() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
         let mut state = make_state();
@@ -4123,7 +4016,6 @@ mod tests {
                 is_current: false,
             },
         ]));
-        state.ui.strip_selection = Some(99);
         state.ui.input.set_text("draft");
 
         let effects = state.reduce(Action::KeyPressed(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT)));
@@ -4136,7 +4028,6 @@ mod tests {
             state.ui.saved_session_picker.is_some(),
             "Alt+Enter is consumed, not treated as picker Enter"
         );
-        assert_eq!(state.ui.strip_selection, Some(99));
         assert_eq!(state.ui.input.text(), "draft");
         assert!(
             !matches!(

--- a/src/chat/state.rs
+++ b/src/chat/state.rs
@@ -1351,6 +1351,19 @@ impl ChatState {
         let approved = match key.code {
             KeyCode::Char('y' | 'Y') => Some(true),
             KeyCode::Char('n' | 'N') | KeyCode::Esc => Some(false),
+            KeyCode::Enter => Some(pending.selected_approval),
+            KeyCode::Left | KeyCode::Up => {
+                if let Some(pending) = self.ui.pending_tool_approval.as_mut() {
+                    pending.selected_approval = false;
+                }
+                return vec![Effect::RequestRedraw];
+            }
+            KeyCode::Right | KeyCode::Down => {
+                if let Some(pending) = self.ui.pending_tool_approval.as_mut() {
+                    pending.selected_approval = true;
+                }
+                return vec![Effect::RequestRedraw];
+            }
             _ => None,
         };
         let Some(approved) = approved else {
@@ -2268,6 +2281,7 @@ impl ChatState {
             tool_id: tool_id.clone(),
             name: name.clone(),
             args: args.clone(),
+            selected_approval: false,
         });
         self.ui.focus = crate::chat::sessions::FocusTarget::Approval;
         self.ui.switcher = None;
@@ -2776,6 +2790,21 @@ impl ChatState {
     }
 
     fn reduce_provider_worker_status_updated(&mut self, status: ProviderWorkerStatus) -> Vec<Effect> {
+        #[cfg(feature = "terminal-tui")]
+        let status = {
+            let mut status = status;
+            if let Some(summary) = crate::chat::tui::latest_provider_worker_tool_summary_from_conversation(
+                &self.ui.conversation_lines,
+                self.ui.ascii_fallback,
+            ) {
+                for row in &mut status.rows {
+                    if row.is_active() {
+                        row.recent_tool_call = Some(summary.clone());
+                    }
+                }
+            }
+            status
+        };
         if self.ui.provider_worker_status == status {
             return Vec::new();
         }
@@ -3558,6 +3587,7 @@ mod tests {
                 started_at_ms: chrono::Utc::now().timestamp_millis(),
                 finalized_total_tokens: None,
                 completion_ready: false,
+                recent_tool_call: None,
             }],
         };
 
@@ -3581,6 +3611,56 @@ mod tests {
             !view.lines.iter().any(|line| line == "output: P6Z"),
             "completed tool output without a matching streaming draft stays out of worker IO: {:?}",
             view.lines
+        );
+    }
+
+    #[cfg(feature = "terminal-tui")]
+    #[test]
+    fn provider_worker_status_update_enriches_running_rows_with_recent_tool_summary() {
+        use crate::chat::tui::{ConversationLine, ToolStatus};
+
+        let mut state = make_state();
+        state.ui.conversation_lines.push(ConversationLine::ToolResult {
+            tool_name: "shell".to_string(),
+            args_preview: "ls /tmp/demo".to_string(),
+            args_full: "{\"command\":\"ls /tmp/demo\"}".to_string(),
+            result: None,
+            status: ToolStatus::Running,
+            elapsed_ms: None,
+            folded: true,
+        });
+        let status = ProviderWorkerStatus {
+            running: 1,
+            cancelling: 0,
+            awaiting_commit: 0,
+            finalized_payloads: 0,
+            finalized_total_tokens: 0,
+            oldest_started_at_ms: Some(0),
+            rows: vec![crate::chat::action::ProviderWorkerStatusRow {
+                task_id: 7,
+                sequence: 2,
+                kind: crate::chat::action::ProviderWorkerRowKind::Detached,
+                state: crate::chat::action::ProviderWorkerRowState::Running,
+                started_at_ms: 0,
+                finalized_total_tokens: None,
+                completion_ready: false,
+                recent_tool_call: None,
+            }],
+        };
+
+        let effects = state.reduce(Action::ProviderWorkerStatusUpdated { status });
+
+        assert!(matches!(effects.as_slice(), [Effect::RequestRedraw]));
+        let summary = state
+            .ui
+            .provider_worker_status
+            .rows
+            .first()
+            .and_then(|row| row.recent_tool_call.as_deref())
+            .expect("running row should receive latest tool summary");
+        assert!(
+            summary.contains("run shell running: ls /tmp/demo"),
+            "summary should use the compact tool-call wording: {summary}"
         );
     }
 
@@ -4163,6 +4243,49 @@ mod tests {
         assert_eq!(pending.tool_id, "call-approve");
         assert_eq!(pending.name, "shell");
         assert!(pending.args.contains("printf secure"));
+        assert!(
+            !pending.selected_approval,
+            "approval selection defaults to the safe deny choice"
+        );
+    }
+
+    #[cfg(feature = "terminal-tui")]
+    #[test]
+    fn redux_approval_arrows_select_and_enter_resolves() {
+        let mut state = make_state();
+        let _ = state.reduce(Action::ToolApprovalRequested {
+            task_id: None,
+            tool_id: "call-arrow-approve".to_string(),
+            name: "shell".to_string(),
+            args: "{}".to_string(),
+        });
+
+        let effects = state.reduce(Action::KeyPressed(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Right,
+            crossterm::event::KeyModifiers::NONE,
+        )));
+        assert!(effects.iter().any(|effect| matches!(effect, Effect::RequestRedraw)));
+        assert!(
+            state
+                .ui
+                .pending_tool_approval
+                .as_ref()
+                .expect("approval remains pending after arrow")
+                .selected_approval,
+            "Right selects approve"
+        );
+
+        let effects = state.reduce(Action::KeyPressed(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Enter,
+            crossterm::event::KeyModifiers::NONE,
+        )));
+        assert!(state.ui.pending_tool_approval.is_none());
+        assert!(effects.iter().any(|effect| {
+            matches!(
+                effect,
+                Effect::ResolveApproval { tool_id, approved: true } if tool_id == "call-arrow-approve"
+            )
+        }));
     }
 
     #[cfg(feature = "terminal-tui")]
@@ -6994,6 +7117,7 @@ mod tests {
                         started_at_ms: 0,
                         finalized_total_tokens: None,
                         completion_ready: false,
+                        recent_tool_call: None,
                     })
                     .collect(),
             }

--- a/src/chat/tui.rs
+++ b/src/chat/tui.rs
@@ -14,7 +14,7 @@
 //! Gated behind the `terminal-tui` feature.
 
 use async_trait::async_trait;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use parking_lot::Mutex;
 use ratatui::Frame;
 use ratatui::buffer::Buffer;
@@ -110,11 +110,6 @@ pub struct TuiState {
     /// Owned by the synchronous key thread (opened/navigated/closed in
     /// `dispatch_global_key`); rendered as a bottom-chrome popup.
     pub switcher: Option<crate::chat::sessions::SwitcherState>,
-    /// UI-only bottom-strip selection for direct Alt+arrow navigation. This is
-    /// deliberately separate from [`crate::chat::sessions::FocusTarget`]: it
-    /// highlights a strip entry but never changes input routing until Alt+Enter
-    /// reuses the existing synthetic `/attach N` path.
-    pub strip_selection: Option<u64>,
     /// Open slash-command menu overlay, or `None` when the cursor is not inside
     /// a leading command token.
     pub slash_menu: Option<SlashMenuState>,
@@ -661,13 +656,22 @@ pub enum KeyDispatch {
     /// key loop sends a synthetic `/attach <seq>` through the input channel so
     /// the async main loop performs the attach via its existing handler.
     AttachSession { seq: u64 },
-    /// Phase B: the bottom strip's UI-only selection changed. `None` clears the
-    /// highlight without changing input-routing focus.
-    StripSelectionChanged { selected: Option<u64> },
     /// v1.1b: detach the focused child session (Esc on empty input while a
     /// session is focused). The key loop sends a synthetic `/detach` through the
     /// input channel so the async main loop performs the detach.
     RequestDetach,
+    /// Scroll the main fullscreen transcript one line up from tail.
+    ScrollTranscriptUp,
+    /// Scroll the main fullscreen transcript one line down toward tail.
+    ScrollTranscriptDown,
+    /// Page the main fullscreen transcript up from tail.
+    PageTranscriptUp,
+    /// Page the main fullscreen transcript down toward tail.
+    PageTranscriptDown,
+    /// Jump the main fullscreen transcript to the oldest visible content.
+    TranscriptHome,
+    /// Jump the main fullscreen transcript to the tail.
+    TranscriptEnd,
     /// P2: scroll the focused child-session viewport one line up from tail.
     ScrollSessionUp,
     /// P2: scroll the focused child-session viewport one line down toward tail.
@@ -676,6 +680,10 @@ pub enum KeyDispatch {
     PageSessionUp,
     /// P2: page the focused child-session viewport down toward tail.
     PageSessionDown,
+    /// P2: jump the focused child-session viewport to the oldest retained line.
+    SessionHome,
+    /// P2: jump the focused child-session viewport to the tail.
+    SessionEnd,
     /// P3: switch to an adjacent live child session through the single `/attach`
     /// owner path.
     SwitchSession { seq: u64 },
@@ -1124,29 +1132,19 @@ fn focus_active_entry_seq(focus: crate::chat::sessions::FocusTarget) -> Option<u
     })
 }
 
-pub(crate) fn strip_selection_index(
+pub(crate) fn focus_entry_index(
     entries: &[crate::chat::sessions::SwitcherEntry],
-    selected: Option<u64>,
     focus: crate::chat::sessions::FocusTarget,
 ) -> Option<usize> {
-    selected
-        .and_then(|seq| entries.iter().position(|entry| entry.seq == seq))
-        .or_else(|| focus_active_entry_seq(focus).and_then(|seq| entries.iter().position(|entry| entry.seq == seq)))
+    focus_active_entry_seq(focus).and_then(|seq| entries.iter().position(|entry| entry.seq == seq))
 }
 
 const MAIN_SESSION_SELECTION_SEQ: u64 = 0;
 
 fn bottom_list_selection_index(
     entries: &[crate::chat::sessions::SwitcherEntry],
-    selected: Option<u64>,
     focus: crate::chat::sessions::FocusTarget,
 ) -> usize {
-    if selected == Some(MAIN_SESSION_SELECTION_SEQ) {
-        return 0;
-    }
-    if let Some(idx) = selected.and_then(|seq| entries.iter().position(|entry| entry.seq == seq)) {
-        return idx.saturating_add(1);
-    }
     focus_active_entry_seq(focus)
         .and_then(|seq| entries.iter().position(|entry| entry.seq == seq))
         .map_or(0, |idx| idx.saturating_add(1))
@@ -1162,7 +1160,6 @@ fn bottom_list_seq_at(entries: &[crate::chat::sessions::SwitcherEntry], idx: usi
 
 fn move_bottom_list_selection(
     entries: &[crate::chat::sessions::SwitcherEntry],
-    selected: Option<u64>,
     focus: crate::chat::sessions::FocusTarget,
     direction: crate::chat::sessions::SessionDirection,
 ) -> Option<u64> {
@@ -1170,7 +1167,7 @@ fn move_bottom_list_selection(
         return None;
     }
     let total = entries.len().saturating_add(1);
-    let current = bottom_list_selection_index(entries, selected, focus).min(total.saturating_sub(1));
+    let current = bottom_list_selection_index(entries, focus).min(total.saturating_sub(1));
     let target_idx = match direction {
         crate::chat::sessions::SessionDirection::Previous => {
             current.checked_sub(1).unwrap_or_else(|| total.saturating_sub(1))
@@ -1205,36 +1202,73 @@ fn bottom_chrome_session_entries_with_workers(
     out
 }
 
-pub(crate) fn move_strip_selection(
-    entries: &[crate::chat::sessions::SwitcherEntry],
-    selected: Option<u64>,
-    focus: crate::chat::sessions::FocusTarget,
-    direction: crate::chat::sessions::SessionDirection,
-) -> Option<u64> {
-    if entries.is_empty() {
-        return None;
-    }
-    let current = strip_selection_index(entries, selected, focus);
-    let target_idx = match (current, direction) {
-        (Some(idx), crate::chat::sessions::SessionDirection::Previous) => {
-            idx.checked_sub(1).unwrap_or_else(|| entries.len().saturating_sub(1))
-        }
-        (Some(idx), crate::chat::sessions::SessionDirection::Next) => {
-            let next = idx.saturating_add(1);
-            if next >= entries.len() { 0 } else { next }
-        }
-        (None, crate::chat::sessions::SessionDirection::Previous) => entries.len().saturating_sub(1),
-        (None, crate::chat::sessions::SessionDirection::Next) => 0,
-    };
-    entries.get(target_idx).map(|entry| entry.seq)
-}
-
 pub(crate) fn selected_strip_entry<'a>(
     entries: &'a [crate::chat::sessions::SwitcherEntry],
     selected: Option<u64>,
 ) -> Option<&'a crate::chat::sessions::SwitcherEntry> {
     let seq = selected?;
     entries.iter().find(|entry| entry.seq == seq)
+}
+
+fn dispatch_bottom_entry_activation(
+    entry: &crate::chat::sessions::SwitcherEntry,
+    current_focus: crate::chat::sessions::FocusTarget,
+) -> KeyDispatch {
+    if is_provider_worker_switcher_entry(entry)
+        && let Some(sequence) = provider_worker_sequence_from_switcher_seq(entry.seq)
+    {
+        return KeyDispatch::OpenProviderWorkerView { sequence };
+    }
+    if current_focus.session_seq() == Some(entry.seq) {
+        return KeyDispatch::Consumed;
+    }
+    if matches!(current_focus, crate::chat::sessions::FocusTarget::Main) {
+        KeyDispatch::AttachSession { seq: entry.seq }
+    } else {
+        KeyDispatch::SwitchSession { seq: entry.seq }
+    }
+}
+
+fn dispatch_main_bottom_switch(state: &TuiState, direction: crate::chat::sessions::SessionDirection) -> KeyDispatch {
+    let bottom_entries = bottom_chrome_session_entries_with_workers(
+        &state.sessions_cache,
+        state.provider_worker_status.clone(),
+        state.focus,
+    );
+    let Some(selected) = move_bottom_list_selection(&bottom_entries, state.focus, direction) else {
+        return KeyDispatch::Consumed;
+    };
+    if selected == MAIN_SESSION_SELECTION_SEQ {
+        return KeyDispatch::Consumed;
+    }
+    selected_strip_entry(&bottom_entries, Some(selected)).map_or(KeyDispatch::Consumed, |entry| {
+        dispatch_bottom_entry_activation(entry, state.focus)
+    })
+}
+
+fn dispatch_child_bottom_switch(state: &TuiState, direction: crate::chat::sessions::SessionDirection) -> KeyDispatch {
+    let bottom_entries = bottom_chrome_session_entries_with_workers(
+        &state.sessions_cache,
+        state.provider_worker_status.clone(),
+        state.focus,
+    );
+    let Some(selected) = move_bottom_list_selection(&bottom_entries, state.focus, direction) else {
+        return KeyDispatch::Consumed;
+    };
+    if selected == MAIN_SESSION_SELECTION_SEQ {
+        return match state.focus {
+            crate::chat::sessions::FocusTarget::Worker { .. } => KeyDispatch::CloseProviderWorkerView,
+            crate::chat::sessions::FocusTarget::Transcript => KeyDispatch::CloseTranscriptViewer,
+            crate::chat::sessions::FocusTarget::Diff => KeyDispatch::CloseDiffViewer,
+            crate::chat::sessions::FocusTarget::Session { .. } => KeyDispatch::RequestDetach,
+            crate::chat::sessions::FocusTarget::Main | crate::chat::sessions::FocusTarget::Approval => {
+                KeyDispatch::Consumed
+            }
+        };
+    }
+    selected_strip_entry(&bottom_entries, Some(selected)).map_or(KeyDispatch::Consumed, |entry| {
+        dispatch_bottom_entry_activation(entry, state.focus)
+    })
 }
 
 const fn tool_status_name(status: ToolStatus) -> &'static str {
@@ -1633,89 +1667,38 @@ pub fn dispatch_global_key(key: KeyEvent, state: &mut TuiState) -> KeyDispatch {
         state.switcher = Some(crate::chat::sessions::SwitcherState::new(entries.clone()));
         return KeyDispatch::SwitcherOpened { entries };
     }
+    if key.modifiers == KeyModifiers::NONE && matches!(state.focus, crate::chat::sessions::FocusTarget::Main) {
+        match key.code {
+            KeyCode::PageUp => return KeyDispatch::PageTranscriptUp,
+            KeyCode::PageDown => return KeyDispatch::PageTranscriptDown,
+            KeyCode::Home => return KeyDispatch::TranscriptHome,
+            KeyCode::End => return KeyDispatch::TranscriptEnd,
+            _ => {}
+        }
+    }
+    if key.modifiers == KeyModifiers::NONE && state.focus.is_child_view() {
+        match key.code {
+            KeyCode::PageUp => return KeyDispatch::PageSessionUp,
+            KeyCode::PageDown => return KeyDispatch::PageSessionDown,
+            KeyCode::Home => return KeyDispatch::SessionHome,
+            KeyCode::End => return KeyDispatch::SessionEnd,
+            _ => {}
+        }
+    }
     if state.input.is_empty()
         && key.modifiers == KeyModifiers::NONE
         && matches!(state.focus, crate::chat::sessions::FocusTarget::Main)
     {
-        let bottom_entries = bottom_chrome_session_entries_with_workers(
-            &state.sessions_cache,
-            state.provider_worker_status.clone(),
-            state.focus,
-        );
-        let direction = match key.code {
-            KeyCode::Left | KeyCode::Up => Some(crate::chat::sessions::SessionDirection::Previous),
-            KeyCode::Right | KeyCode::Down => Some(crate::chat::sessions::SessionDirection::Next),
-            _ => None,
-        };
-        if let Some(direction) = direction {
-            if !bottom_entries.is_empty() {
-                let selected =
-                    move_bottom_list_selection(&bottom_entries, state.strip_selection, state.focus, direction);
-                state.strip_selection = selected;
-                return KeyDispatch::StripSelectionChanged { selected };
+        match key.code {
+            KeyCode::Up => return KeyDispatch::ScrollTranscriptUp,
+            KeyCode::Down => return KeyDispatch::ScrollTranscriptDown,
+            KeyCode::Left if key.kind == KeyEventKind::Repeat => return KeyDispatch::Consumed,
+            KeyCode::Right if key.kind == KeyEventKind::Repeat => return KeyDispatch::Consumed,
+            KeyCode::Left => {
+                return dispatch_main_bottom_switch(state, crate::chat::sessions::SessionDirection::Previous);
             }
-        }
-        if key.code == KeyCode::Enter
-            && let Some(selected) = state.strip_selection
-        {
-            if selected == MAIN_SESSION_SELECTION_SEQ {
-                state.strip_selection = None;
-                return KeyDispatch::Consumed;
-            }
-            if let Some(entry) = selected_strip_entry(&bottom_entries, Some(selected)) {
-                state.strip_selection = None;
-                if is_provider_worker_switcher_entry(entry)
-                    && let Some(sequence) = provider_worker_sequence_from_switcher_seq(entry.seq)
-                {
-                    return KeyDispatch::OpenProviderWorkerView { sequence };
-                }
-                return KeyDispatch::AttachSession { seq: entry.seq };
-            }
-            state.strip_selection = None;
-            state.push_system_message("session gone");
-            return KeyDispatch::Consumed;
-        }
-    }
-    if key.modifiers == KeyModifiers::ALT {
-        let direction = match key.code {
-            KeyCode::Left | KeyCode::Up => Some(crate::chat::sessions::SessionDirection::Previous),
-            KeyCode::Right | KeyCode::Down => Some(crate::chat::sessions::SessionDirection::Next),
-            _ => None,
-        };
-        if let Some(direction) = direction {
-            let entries = bottom_chrome_session_entries_with_workers(
-                &state.sessions_cache,
-                state.provider_worker_status.clone(),
-                state.focus,
-            );
-            let selected = move_strip_selection(&entries, state.strip_selection, state.focus, direction);
-            state.strip_selection = selected;
-            return KeyDispatch::StripSelectionChanged { selected };
-        }
-        if key.code == KeyCode::Enter {
-            if let Some(selected) = state.strip_selection {
-                let entries = bottom_chrome_session_entries_with_workers(
-                    &state.sessions_cache,
-                    state.provider_worker_status.clone(),
-                    state.focus,
-                );
-                if selected == MAIN_SESSION_SELECTION_SEQ {
-                    state.strip_selection = None;
-                    return KeyDispatch::RequestDetach;
-                }
-                if let Some(entry) = selected_strip_entry(&entries, Some(selected)) {
-                    state.strip_selection = None;
-                    if is_provider_worker_switcher_entry(entry)
-                        && let Some(sequence) = provider_worker_sequence_from_switcher_seq(entry.seq)
-                    {
-                        return KeyDispatch::OpenProviderWorkerView { sequence };
-                    }
-                    return KeyDispatch::AttachSession { seq: entry.seq };
-                }
-                state.strip_selection = None;
-                state.push_system_message("session gone");
-                return KeyDispatch::Consumed;
-            }
+            KeyCode::Right => return dispatch_main_bottom_switch(state, crate::chat::sessions::SessionDirection::Next),
+            _ => {}
         }
     }
     if key.code == KeyCode::Char('o') && key.modifiers == KeyModifiers::CONTROL {
@@ -1750,82 +1733,23 @@ pub fn dispatch_global_key(key: KeyEvent, state: &mut TuiState) -> KeyDispatch {
         let _ = state.handle_input_key(synthetic);
         return KeyDispatch::Consumed;
     }
-    if let Some(current_seq) = state.focus.session_seq()
-        && state.input.is_empty()
-        && key.modifiers == KeyModifiers::NONE
-    {
+    if state.focus.is_child_view() && state.input.is_empty() && key.modifiers == KeyModifiers::NONE {
         let direction = match key.code {
-            KeyCode::Left | KeyCode::Up => Some(crate::chat::sessions::SessionDirection::Previous),
-            KeyCode::Right | KeyCode::Down => Some(crate::chat::sessions::SessionDirection::Next),
+            KeyCode::Left => Some(crate::chat::sessions::SessionDirection::Previous),
+            KeyCode::Right => Some(crate::chat::sessions::SessionDirection::Next),
             _ => None,
         };
         if let Some(direction) = direction {
-            let bottom_entries = bottom_chrome_session_entries_with_workers(
-                &state.sessions_cache,
-                state.provider_worker_status.clone(),
-                state.focus,
-            );
-            if !bottom_entries.is_empty() {
-                let selected = move_bottom_list_selection(&bottom_entries, None, state.focus, direction);
-                return match selected {
-                    Some(MAIN_SESSION_SELECTION_SEQ) => KeyDispatch::RequestDetach,
-                    Some(seq) => {
-                        if let Some(entry) = selected_strip_entry(&bottom_entries, Some(seq))
-                            && is_provider_worker_switcher_entry(entry)
-                            && let Some(sequence) = provider_worker_sequence_from_switcher_seq(entry.seq)
-                        {
-                            return KeyDispatch::OpenProviderWorkerView { sequence };
-                        }
-                        if seq != current_seq {
-                            return KeyDispatch::SwitchSession { seq };
-                        }
-                        KeyDispatch::Consumed
-                    }
-                    None => KeyDispatch::Consumed,
-                };
+            if key.kind == KeyEventKind::Repeat {
+                return KeyDispatch::Consumed;
             }
-        }
-    }
-    if matches!(state.focus, crate::chat::sessions::FocusTarget::Worker { .. })
-        && state.input.is_empty()
-        && key.modifiers == KeyModifiers::NONE
-    {
-        let direction = match key.code {
-            KeyCode::Left | KeyCode::Up => Some(crate::chat::sessions::SessionDirection::Previous),
-            KeyCode::Right | KeyCode::Down => Some(crate::chat::sessions::SessionDirection::Next),
-            _ => None,
-        };
-        if let Some(direction) = direction {
-            let bottom_entries = bottom_chrome_session_entries_with_workers(
-                &state.sessions_cache,
-                state.provider_worker_status.clone(),
-                state.focus,
-            );
-            if !bottom_entries.is_empty() {
-                let selected = move_bottom_list_selection(&bottom_entries, None, state.focus, direction);
-                return match selected {
-                    Some(MAIN_SESSION_SELECTION_SEQ) => KeyDispatch::CloseProviderWorkerView,
-                    Some(seq) => {
-                        if let Some(entry) = selected_strip_entry(&bottom_entries, Some(seq)) {
-                            if is_provider_worker_switcher_entry(entry)
-                                && let Some(sequence) = provider_worker_sequence_from_switcher_seq(entry.seq)
-                            {
-                                return KeyDispatch::OpenProviderWorkerView { sequence };
-                            }
-                        }
-                        KeyDispatch::SwitchSession { seq }
-                    }
-                    None => KeyDispatch::Consumed,
-                };
-            }
+            return dispatch_child_bottom_switch(state, direction);
         }
     }
     if state.focus.is_child_view() && state.input.is_empty() && key.modifiers == KeyModifiers::NONE {
         match key.code {
             KeyCode::Up => return KeyDispatch::ScrollSessionUp,
             KeyCode::Down => return KeyDispatch::ScrollSessionDown,
-            KeyCode::PageUp => return KeyDispatch::PageSessionUp,
-            KeyCode::PageDown => return KeyDispatch::PageSessionDown,
             _ => {}
         }
     }
@@ -1834,9 +1758,6 @@ pub fn dispatch_global_key(key: KeyEvent, state: &mut TuiState) -> KeyDispatch {
     // between the established "non-empty clears input" muscle memory and the new
     // "empty + session focused → detach" behaviour, never weakening the former.
     if key.code == KeyCode::Esc && key.modifiers == KeyModifiers::NONE {
-        if state.strip_selection.take().is_some() {
-            return KeyDispatch::StripSelectionChanged { selected: None };
-        }
         use crate::chat::sessions::focus::{EscAction, resolve_esc};
         match resolve_esc(state.input.is_empty(), state.focus, false, state.streaming.is_some()) {
             EscAction::CancelGenerating => return KeyDispatch::InterruptTurn,
@@ -3015,6 +2936,26 @@ impl TuiInput {
             return self.handle_reverse_search_key(key);
         }
 
+        if ctrl && !alt {
+            match key.code {
+                KeyCode::Char('p' | 'P') => {
+                    return if self.history_prev() {
+                        InputOutcome::Consumed
+                    } else {
+                        InputOutcome::Unhandled
+                    };
+                }
+                KeyCode::Char('n' | 'N') => {
+                    return if self.history_next() {
+                        InputOutcome::Consumed
+                    } else {
+                        InputOutcome::Unhandled
+                    };
+                }
+                _ => {}
+            }
+        }
+
         match key.code {
             KeyCode::Enter => {
                 if shift || alt {
@@ -3088,27 +3029,14 @@ impl TuiInput {
                 InputOutcome::Consumed
             }
             KeyCode::Up => {
-                // Single-line buffer → history; multi-line → cursor up.
-                if self.is_single_line() {
-                    if self.history_prev() {
-                        InputOutcome::Consumed
-                    } else {
-                        InputOutcome::Unhandled
-                    }
-                } else if self.move_cursor_up() {
+                if !self.is_single_line() && self.move_cursor_up() {
                     InputOutcome::Consumed
                 } else {
                     InputOutcome::Unhandled
                 }
             }
             KeyCode::Down => {
-                if self.is_single_line() {
-                    if self.history_next() {
-                        InputOutcome::Consumed
-                    } else {
-                        InputOutcome::Unhandled
-                    }
-                } else if self.move_cursor_down() {
+                if !self.is_single_line() && self.move_cursor_down() {
                     InputOutcome::Consumed
                 } else {
                     InputOutcome::Unhandled
@@ -3197,7 +3125,6 @@ impl TuiState {
             sessions_status: String::new(),
             focus: crate::chat::sessions::FocusTarget::Main,
             switcher: None,
-            strip_selection: None,
             slash_menu: None,
             sessions_cache: Vec::new(),
             main_queue_status: MainQueueStatus::default(),
@@ -3832,8 +3759,6 @@ pub trait BottomChromeView {
     fn main_queue_status(&self) -> MainQueueStatus;
     /// Main-session provider worker status.
     fn provider_worker_status(&self) -> ProviderWorkerStatus;
-    /// UI-only bottom-strip selection, separate from input-routing focus.
-    fn strip_selection(&self) -> Option<u64>;
     /// Focused line-session viewport (P2), if any.
     fn active_session_view(&self) -> Option<&crate::chat::sessions::ActiveSessionView>;
     /// Foreground tool approval prompt (P6c1), if any.
@@ -3897,9 +3822,6 @@ impl BottomChromeView for TuiState {
     }
     fn provider_worker_status(&self) -> ProviderWorkerStatus {
         self.provider_worker_status.clone()
-    }
-    fn strip_selection(&self) -> Option<u64> {
-        self.strip_selection
     }
     fn active_session_view(&self) -> Option<&crate::chat::sessions::ActiveSessionView> {
         self.active_session_view.as_ref()
@@ -3973,9 +3895,6 @@ impl BottomChromeView for crate::chat::state::UiSnapshot {
     fn provider_worker_status(&self) -> ProviderWorkerStatus {
         self.provider_worker_status.clone()
     }
-    fn strip_selection(&self) -> Option<u64> {
-        self.strip_selection
-    }
     fn active_session_view(&self) -> Option<&crate::chat::sessions::ActiveSessionView> {
         self.active_session_view.as_ref()
     }
@@ -4031,6 +3950,14 @@ pub struct FullscreenTranscriptScroll {
 }
 
 impl FullscreenTranscriptScroll {
+    pub fn line_up(&mut self) {
+        self.page_up(1);
+    }
+
+    pub fn line_down(&mut self) {
+        self.page_down(1);
+    }
+
     pub fn page_up(&mut self, rows: usize) {
         self.offset_from_bottom = self.offset_from_bottom.saturating_add(rows.max(1));
         self.anchor_top_row = None;
@@ -4616,7 +4543,6 @@ fn render_sessions_strip_entry(
 fn render_sessions_list_entry_line(
     entry: &crate::chat::sessions::SwitcherEntry,
     active_seq: Option<u64>,
-    strip_selection: Option<u64>,
     ascii: bool,
     width: u16,
 ) -> Line<'static> {
@@ -4624,7 +4550,6 @@ fn render_sessions_list_entry_line(
         return Line::default();
     }
     let active = active_seq == Some(entry.seq);
-    let selected = strip_selection == Some(entry.seq);
     let marker = session_active_marker(active, ascii);
     let glyph = session_status_glyph(entry, ascii);
     let idle = if entry.idle_warning {
@@ -4653,12 +4578,7 @@ fn render_sessions_list_entry_line(
         text.push_str(&entry.title);
     }
     let text = truncate_chars_with_ellipsis(&text, width, ascii);
-    let style = if selected {
-        Style::default()
-            .fg(Color::Black)
-            .bg(Color::Cyan)
-            .add_modifier(Modifier::BOLD)
-    } else if active {
+    let style = if active {
         Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
     } else if entry.is_terminal() {
         Style::default().fg(Color::DarkGray)
@@ -4671,7 +4591,6 @@ fn render_sessions_list_entry_line(
 fn render_main_session_list_line<V: BottomChromeView + ?Sized>(state: &V, width: u16) -> Line<'static> {
     let ascii = state.ascii_fallback();
     let active = matches!(state.focus(), crate::chat::sessions::FocusTarget::Main);
-    let selected = state.strip_selection() == Some(MAIN_SESSION_SELECTION_SEQ);
     let marker = session_active_marker(active, ascii);
     let sep = if ascii { " | " } else { " · " };
     let usage = render_main_token_usage(state.token_usage_summary());
@@ -4685,12 +4604,7 @@ fn render_main_session_list_line<V: BottomChromeView + ?Sized>(state: &V, width:
         state.model()
     );
     let text = truncate_chars_with_ellipsis(&text, width, ascii);
-    let style = if selected {
-        Style::default()
-            .fg(Color::Black)
-            .bg(Color::Cyan)
-            .add_modifier(Modifier::BOLD)
-    } else if active {
+    let style = if active {
         Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::DarkGray)
@@ -4698,16 +4612,21 @@ fn render_main_session_list_line<V: BottomChromeView + ?Sized>(state: &V, width:
     Line::from(Span::styled(text, style))
 }
 
-const fn sessions_navigation_hint(ascii: bool) -> &'static str {
-    if ascii {
-        " Up/Down sessions | Enter attach/open "
-    } else {
-        " \u{2191}\u{2193} sessions \u{00B7} Enter attach/open "
+const fn sessions_navigation_hint(ascii: bool, child_focus: bool) -> &'static str {
+    match (ascii, child_focus) {
+        (true, true) => " Up/Down scroll | Left/Right switch | Esc back ",
+        (false, true) => " \u{2191}/\u{2193} scroll \u{00B7} \u{2190}/\u{2192} switch \u{00B7} Esc back ",
+        (true, false) => " Left/Right session ",
+        (false, false) => " \u{2190}/\u{2192} session ",
     }
 }
 
-fn render_sessions_navigation_hint_line(ascii: bool, width: u16) -> Line<'static> {
-    let text = truncate_chars_with_ellipsis(sessions_navigation_hint(ascii), width, ascii);
+fn render_sessions_navigation_hint_line(
+    ascii: bool,
+    focus: crate::chat::sessions::FocusTarget,
+    width: u16,
+) -> Line<'static> {
+    let text = truncate_chars_with_ellipsis(sessions_navigation_hint(ascii, focus.is_child_view()), width, ascii);
     Line::from(Span::styled(text, Style::default().fg(Color::DarkGray)))
 }
 
@@ -4720,7 +4639,6 @@ fn render_sessions_list_lines<V: BottomChromeView + ?Sized>(
     let focus = state.focus();
     let entries =
         bottom_chrome_session_entries_with_workers(state.sessions_entries(), state.provider_worker_status(), focus);
-    let strip_selection = state.strip_selection();
     let ascii = state.ascii_fallback();
     if width == 0 || max_rows == 0 {
         return Vec::new();
@@ -4734,7 +4652,7 @@ fn render_sessions_list_lines<V: BottomChromeView + ?Sized>(
     let active_seq = focus_active_entry_seq(focus);
     let total = entries.len().saturating_add(1);
     let list_rows = max_rows.saturating_sub(1).max(1);
-    let target_idx = bottom_list_selection_index(&entries, strip_selection, focus).min(total.saturating_sub(1));
+    let target_idx = bottom_list_selection_index(&entries, focus).min(total.saturating_sub(1));
     let start = if total <= list_rows {
         0
     } else {
@@ -4745,17 +4663,11 @@ fn render_sessions_list_lines<V: BottomChromeView + ?Sized>(
         if idx == 0 {
             lines.push(render_main_session_list_line(state, width));
         } else if let Some(entry) = entries.get(idx.saturating_sub(1)) {
-            lines.push(render_sessions_list_entry_line(
-                entry,
-                active_seq,
-                strip_selection,
-                ascii,
-                width,
-            ));
+            lines.push(render_sessions_list_entry_line(entry, active_seq, ascii, width));
         }
     }
     if lines.len() < max_rows {
-        lines.push(render_sessions_navigation_hint_line(ascii, width));
+        lines.push(render_sessions_navigation_hint_line(ascii, focus, width));
     }
     lines
 }
@@ -4767,18 +4679,7 @@ fn render_sessions_strip_line(
     ascii: bool,
     width: u16,
 ) -> String {
-    render_sessions_strip_line_with_selection(entries, summary, focus, None, ascii, width)
-}
-
-fn render_sessions_strip_line_with_selection(
-    entries: &[crate::chat::sessions::SwitcherEntry],
-    summary: &str,
-    focus: crate::chat::sessions::FocusTarget,
-    strip_selection: Option<u64>,
-    ascii: bool,
-    width: u16,
-) -> String {
-    render_sessions_strip_styled_line(entries, summary, focus, strip_selection, ascii, width)
+    render_sessions_strip_styled_line(entries, summary, focus, ascii, width)
         .spans
         .iter()
         .map(|span| span.content.as_ref())
@@ -4789,7 +4690,6 @@ fn render_sessions_strip_styled_line(
     entries: &[crate::chat::sessions::SwitcherEntry],
     summary: &str,
     focus: crate::chat::sessions::FocusTarget,
-    strip_selection: Option<u64>,
     ascii: bool,
     width: u16,
 ) -> Line<'static> {
@@ -4809,7 +4709,7 @@ fn render_sessions_strip_styled_line(
     }
 
     let active_seq = focus_active_entry_seq(focus);
-    let target_idx = strip_selection_index(entries, strip_selection, focus);
+    let target_idx = focus_entry_index(entries, focus);
     let start = target_idx
         .map(|target| sessions_strip_window_start(entries, active_seq, ascii, content_width, target))
         .unwrap_or(0);
@@ -4818,7 +4718,6 @@ fn render_sessions_strip_styled_line(
         entries,
         start,
         active_seq,
-        strip_selection,
         ascii,
         content_width,
     ));
@@ -4901,7 +4800,6 @@ fn render_sessions_strip_window(
     entries: &[crate::chat::sessions::SwitcherEntry],
     start: usize,
     active_seq: Option<u64>,
-    strip_selection: Option<u64>,
     ascii: bool,
     width: u16,
 ) -> Vec<Span<'static>> {
@@ -4947,18 +4845,7 @@ fn render_sessions_strip_window(
         {
             break;
         }
-        let selected = strip_selection == Some(entry.seq);
-        if selected {
-            spans.push(Span::styled(
-                segment,
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ));
-        } else {
-            spans.push(Span::raw(segment));
-        }
+        spans.push(Span::raw(segment));
         used_cols = used_cols.saturating_add(segment_cols);
     }
 
@@ -7141,6 +7028,12 @@ fn footer_text(ascii: bool, show_session_hint: bool) -> String {
     // editor parity is available through the alternate Ctrl+X Ctrl+E chord.
     let sep = if ascii { " | " } else { " \u{00B7} " };
     let mut parts = Vec::from([
+        if ascii {
+            "Up/Down scroll"
+        } else {
+            "\u{2191}/\u{2193} scroll"
+        },
+        "Ctrl+P/N history",
         "Ctrl+G sessions",
         "Ctrl+O transcript",
         "/copy latest",
@@ -7151,7 +7044,7 @@ fn footer_text(ascii: bool, show_session_hint: bool) -> String {
         "Esc cancel",
     ]);
     if show_session_hint {
-        parts.insert(1, sessions_navigation_hint(ascii).trim());
+        parts.insert(1, sessions_navigation_hint(ascii, false).trim());
     }
     format!(" {} ", parts.join(sep))
 }
@@ -8791,6 +8684,15 @@ mod tests {
         KeyEvent::new(code, m)
     }
 
+    fn key_repeat(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Repeat,
+            state: crossterm::event::KeyEventState::NONE,
+        }
+    }
+
     fn saved_picker_entry(id: &str, title: &str, is_current: bool) -> crate::chat::session::SavedSessionPickerEntry {
         crate::chat::session::SavedSessionPickerEntry {
             id: id.to_string(),
@@ -8886,22 +8788,20 @@ mod tests {
     }
 
     #[test]
-    fn p2_10_history_up_recalls_last_submission() {
+    fn p2_10_history_ctrl_p_recalls_last_submission() {
         let mut input = TuiInput::new();
         type_str(&mut input, "first");
         input.handle_key(key(KeyCode::Enter));
         type_str(&mut input, "second");
         input.handle_key(key(KeyCode::Enter));
-        // Single-line buffer → Up walks history backward.
-        let out = input.handle_key(key(KeyCode::Up));
+        let out = input.handle_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL));
         assert_eq!(out, InputOutcome::Consumed);
         assert_eq!(input.text(), "second");
-        input.handle_key(key(KeyCode::Up));
+        input.handle_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL));
         assert_eq!(input.text(), "first");
-        // Down → second → fresh empty.
-        input.handle_key(key(KeyCode::Down));
+        input.handle_key(key_mod(KeyCode::Char('n'), KeyModifiers::CONTROL));
         assert_eq!(input.text(), "second");
-        input.handle_key(key(KeyCode::Down));
+        input.handle_key(key_mod(KeyCode::Char('n'), KeyModifiers::CONTROL));
         assert!(input.is_empty(), "back to fresh draft");
     }
 
@@ -8910,11 +8810,12 @@ mod tests {
         let mut input = TuiInput::new();
         type_str(&mut input, "old");
         input.handle_key(key(KeyCode::Enter));
-        // Start typing a new draft, then navigate up & back down.
+        // Start typing a new draft, then navigate back through history and
+        // forward to the draft with Ctrl+P/N.
         type_str(&mut input, "wip");
-        input.handle_key(key(KeyCode::Up));
+        input.handle_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL));
         assert_eq!(input.text(), "old");
-        input.handle_key(key(KeyCode::Down));
+        input.handle_key(key_mod(KeyCode::Char('n'), KeyModifiers::CONTROL));
         assert_eq!(input.text(), "wip", "draft restored");
     }
 
@@ -9343,28 +9244,40 @@ mod tests {
     }
 
     #[test]
-    fn input_history_up_down_still_work_when_slash_menu_closed() {
+    fn input_history_moves_to_ctrl_p_n_when_slash_menu_closed() {
         let mut state = TuiState::new("p", "m");
         state.input.history.push("older command".to_string());
 
-        // Contract B: with no bottom strip entries, bare Up/Down still reach
-        // input history.
-        assert_eq!(dispatch_global_key(key(KeyCode::Up), &mut state), KeyDispatch::Consumed);
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Up), &mut state),
+            KeyDispatch::ScrollTranscriptUp
+        );
+        assert!(state.input.is_empty());
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Down), &mut state),
+            KeyDispatch::ScrollTranscriptDown
+        );
+        assert_eq!(
+            dispatch_global_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL), &mut state),
+            KeyDispatch::Consumed
+        );
         assert_eq!(state.input.text(), "older command");
         assert!(state.slash_menu.is_none());
         assert_eq!(
-            dispatch_global_key(key(KeyCode::Down), &mut state),
+            dispatch_global_key(key_mod(KeyCode::Char('n'), KeyModifiers::CONTROL), &mut state),
             KeyDispatch::Consumed
         );
         assert!(state.input.is_empty());
 
-        // Once the strip has navigable entries, bare arrows drive the strip
-        // instead of recalling history.
         state.sessions_cache = vec![entry(1)];
         state.input.history.push("newer command".to_string());
         assert_eq!(
             dispatch_global_key(key(KeyCode::Down), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(1) }
+            KeyDispatch::ScrollTranscriptDown
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Right), &mut state),
+            KeyDispatch::AttachSession { seq: 1 }
         );
         assert!(state.input.is_empty());
     }
@@ -9624,34 +9537,41 @@ mod tests {
     }
 
     #[test]
-    fn input_history_edit_then_up_down_steps_clean_entries() {
+    fn input_history_edit_then_ctrl_p_n_steps_clean_entries() {
         let mut state = TuiState::new("p", "m");
         state.input.history.push("one".to_string());
         state.input.history.push("two".to_string());
 
-        // Contract B: input history remains reachable when there are no
-        // bottom strip entries for bare arrows to navigate.
-        assert_eq!(dispatch_global_key(key(KeyCode::Up), &mut state), KeyDispatch::Consumed);
+        assert_eq!(
+            dispatch_global_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL), &mut state),
+            KeyDispatch::Consumed
+        );
         assert_eq!(state.input.text(), "two");
         assert_eq!(
             dispatch_global_key(key(KeyCode::Char('!')), &mut state),
             KeyDispatch::Consumed
         );
         assert_eq!(state.input.text(), "two!");
-        assert_eq!(dispatch_global_key(key(KeyCode::Up), &mut state), KeyDispatch::Consumed);
-        assert_eq!(state.input.text(), "two", "Up restarts from a clean history entry");
-        assert_eq!(dispatch_global_key(key(KeyCode::Up), &mut state), KeyDispatch::Consumed);
+        assert_eq!(
+            dispatch_global_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL), &mut state),
+            KeyDispatch::Consumed
+        );
+        assert_eq!(state.input.text(), "two", "Ctrl+P restarts from a clean history entry");
+        assert_eq!(
+            dispatch_global_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL), &mut state),
+            KeyDispatch::Consumed
+        );
         assert_eq!(state.input.text(), "one");
         assert_eq!(
-            dispatch_global_key(key(KeyCode::Down), &mut state),
+            dispatch_global_key(key_mod(KeyCode::Char('n'), KeyModifiers::CONTROL), &mut state),
             KeyDispatch::Consumed
         );
         assert_eq!(state.input.text(), "two");
         assert_eq!(
-            dispatch_global_key(key(KeyCode::Down), &mut state),
+            dispatch_global_key(key_mod(KeyCode::Char('n'), KeyModifiers::CONTROL), &mut state),
             KeyDispatch::Consumed
         );
-        assert_eq!(state.input.text(), "two!", "Down restores the edited draft");
+        assert_eq!(state.input.text(), "two!", "Ctrl+N restores the edited draft");
     }
 
     #[test]
@@ -10048,15 +9968,21 @@ mod tests {
     }
 
     #[test]
-    fn saved_session_picker_closed_keeps_up_down_input_history_behavior() {
+    fn saved_session_picker_closed_keeps_ctrl_p_n_input_history_behavior() {
         let mut state = TuiState::new("p", "m");
         state.input.history = vec!["alpha".to_string(), "beta".to_string()];
-        // Contract B: closing the saved-session picker restores normal input
-        // history when no bottom strip entries are present.
-        assert_eq!(dispatch_global_key(key(KeyCode::Up), &mut state), KeyDispatch::Consumed);
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Up), &mut state),
+            KeyDispatch::ScrollTranscriptUp
+        );
+        assert!(state.input.is_empty());
+        assert_eq!(
+            dispatch_global_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL), &mut state),
+            KeyDispatch::Consumed
+        );
         assert_eq!(state.input.text(), "beta");
         assert_eq!(
-            dispatch_global_key(key(KeyCode::Down), &mut state),
+            dispatch_global_key(key_mod(KeyCode::Char('n'), KeyModifiers::CONTROL), &mut state),
             KeyDispatch::Consumed
         );
         assert!(state.input.is_empty());
@@ -10064,8 +9990,8 @@ mod tests {
         state.sessions_cache = vec![entry(1)];
         assert_eq!(
             dispatch_global_key(key(KeyCode::Down), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(1) },
-            "with strip entries present, bare arrows return to strip navigation"
+            KeyDispatch::ScrollTranscriptDown,
+            "bare Down keeps transcript scroll even when bottom entries exist"
         );
     }
 
@@ -10406,7 +10332,7 @@ mod tests {
         for ch in "abc".chars() {
             dispatch_global_key(key(KeyCode::Char(ch)), &mut state);
         }
-        dispatch_global_key(key(KeyCode::Home), &mut state);
+        dispatch_global_key(key_mod(KeyCode::Char('a'), KeyModifiers::CONTROL), &mut state);
         assert_eq!(state.input.text(), "abc");
         // Ctrl+D should forward-delete 'a' instead of exiting.
         let out = dispatch_global_key(key_mod(KeyCode::Char('d'), KeyModifiers::CONTROL), &mut state);
@@ -10415,15 +10341,44 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_pageup_pagedown_are_consumed_without_scroll() {
-        // Transcript scroll is owned by the outer fullscreen event loop. The
-        // pure dispatcher consumes the key without mutating input.
+    fn dispatch_page_home_end_scroll_main_transcript_even_with_input() {
         let mut state = TuiState::new("p", "m");
         let out = dispatch_global_key(key(KeyCode::PageUp), &mut state);
-        assert_eq!(out, KeyDispatch::Consumed);
+        assert_eq!(out, KeyDispatch::PageTranscriptUp);
         let out = dispatch_global_key(key(KeyCode::PageDown), &mut state);
-        assert_eq!(out, KeyDispatch::Consumed);
+        assert_eq!(out, KeyDispatch::PageTranscriptDown);
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Home), &mut state),
+            KeyDispatch::TranscriptHome
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::End), &mut state),
+            KeyDispatch::TranscriptEnd
+        );
         assert!(state.input.is_empty(), "PgUp/PgDn must not leak into input");
+
+        dispatch_global_key(key(KeyCode::Char('x')), &mut state);
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::PageUp), &mut state),
+            KeyDispatch::PageTranscriptUp,
+            "PageUp still scrolls transcript with a draft present"
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::PageDown), &mut state),
+            KeyDispatch::PageTranscriptDown,
+            "PageDown still scrolls transcript with a draft present"
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Home), &mut state),
+            KeyDispatch::TranscriptHome,
+            "Home still jumps transcript with a draft present"
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::End), &mut state),
+            KeyDispatch::TranscriptEnd,
+            "End still jumps transcript with a draft present"
+        );
+        assert_eq!(state.input.text(), "x", "Page/Home/End must not edit the draft");
     }
 
     #[test]
@@ -10431,8 +10386,6 @@ mod tests {
         let mut state = TuiState::new("p", "m");
         state.focus = crate::chat::sessions::FocusTarget::Session { seq: 9 };
 
-        // Contract B: with no bottom strip entries, child focus keeps bare
-        // Up/Down available for child viewport scrolling.
         assert_eq!(
             dispatch_global_key(key(KeyCode::Up), &mut state),
             KeyDispatch::ScrollSessionUp
@@ -10449,20 +10402,33 @@ mod tests {
             dispatch_global_key(key(KeyCode::PageDown), &mut state),
             KeyDispatch::PageSessionDown
         );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Home), &mut state),
+            KeyDispatch::SessionHome
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::End), &mut state),
+            KeyDispatch::SessionEnd
+        );
 
         state.sessions_cache = vec![entry(9), entry(10)];
         assert_eq!(
             dispatch_global_key(key(KeyCode::Down), &mut state),
+            KeyDispatch::ScrollSessionDown,
+            "with bottom entries present, bare Down still scrolls child output"
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Right), &mut state),
             KeyDispatch::SwitchSession { seq: 10 },
-            "with bottom entries present, bare Down navigates child sessions"
+            "bare Right switches child sessions"
         );
         state.sessions_cache.clear();
 
         state.focus = crate::chat::sessions::FocusTarget::Main;
         assert_eq!(
             dispatch_global_key(key(KeyCode::PageUp), &mut state),
-            KeyDispatch::Consumed,
-            "main focus must not route PgUp into child viewport scrolling"
+            KeyDispatch::PageTranscriptUp,
+            "main focus routes PgUp into transcript scrolling"
         );
 
         state.focus = crate::chat::sessions::FocusTarget::Transcript;
@@ -10516,8 +10482,18 @@ mod tests {
         assert_eq!(state.input.text(), "x");
         assert_eq!(
             dispatch_global_key(key(KeyCode::PageDown), &mut state),
-            KeyDispatch::Consumed,
-            "non-empty input keeps edit/history semantics instead of child scroll"
+            KeyDispatch::PageSessionDown,
+            "PageDown still scrolls child output with a draft present"
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Home), &mut state),
+            KeyDispatch::SessionHome,
+            "Home still jumps child output with a draft present"
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::End), &mut state),
+            KeyDispatch::SessionEnd,
+            "End still jumps child output with a draft present"
         );
 
         state.input.clear();
@@ -10538,40 +10514,30 @@ mod tests {
 
         assert_eq!(
             dispatch_global_key(key(KeyCode::Right), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(1) },
-            "main+empty Right selects the first bottom-rail session"
+            KeyDispatch::AttachSession { seq: 1 },
+            "main+empty Right immediately attaches the first bottom entry"
         );
-        state.strip_selection = None;
-        assert_eq!(
-            dispatch_global_key(key(KeyCode::Down), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(1) },
-            "main+empty Down selects the first bottom-list session"
-        );
-        assert_eq!(state.strip_selection, Some(1));
         assert_eq!(
             dispatch_global_key(key(KeyCode::Up), &mut state),
-            KeyDispatch::StripSelectionChanged {
-                selected: Some(MAIN_SESSION_SELECTION_SEQ)
-            },
-            "main+empty Up moves from first child back to main"
+            KeyDispatch::ScrollTranscriptUp,
+            "main+empty Up scrolls the transcript"
         );
-        assert_eq!(state.strip_selection, Some(MAIN_SESSION_SELECTION_SEQ));
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Down), &mut state),
+            KeyDispatch::ScrollTranscriptDown,
+            "main+empty Down scrolls the transcript"
+        );
         assert_eq!(
             dispatch_global_key(key(KeyCode::Left), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(3) },
-            "main+empty Left wraps from main to the last child session"
-        );
-        assert_eq!(
-            dispatch_global_key(key(KeyCode::Enter), &mut state),
             KeyDispatch::AttachSession { seq: 3 },
-            "main+empty Enter attaches the selected bottom-rail session"
+            "main+empty Left wraps from main to the last bottom entry"
         );
         assert_eq!(
-            state.strip_selection, None,
-            "attach consumes the UI-only strip selection so Esc detaches the child view next"
+            dispatch_global_key(key_repeat(KeyCode::Left), &mut state),
+            KeyDispatch::Consumed,
+            "held Left/Right repeats are debounced before synthetic attach"
         );
 
-        state.strip_selection = None;
         state.focus = crate::chat::sessions::FocusTarget::Session { seq: 2 };
         assert_eq!(
             dispatch_global_key(key(KeyCode::Right), &mut state),
@@ -10580,14 +10546,20 @@ mod tests {
         );
         assert_eq!(
             dispatch_global_key(key(KeyCode::Up), &mut state),
-            KeyDispatch::SwitchSession { seq: 1 },
-            "session+empty Up switches to the visual neighbor above"
+            KeyDispatch::ScrollSessionUp,
+            "session+empty Up scrolls the child viewport"
         );
         state.focus = crate::chat::sessions::FocusTarget::Session { seq: 1 };
         assert_eq!(
-            dispatch_global_key(key(KeyCode::Up), &mut state),
+            dispatch_global_key(key(KeyCode::Left), &mut state),
             KeyDispatch::RequestDetach,
-            "first child+empty Up switches back to main"
+            "first child+empty Left switches back to main"
+        );
+        state.focus = crate::chat::sessions::FocusTarget::Session { seq: 2 };
+        assert_eq!(
+            dispatch_global_key(key_repeat(KeyCode::Right), &mut state),
+            KeyDispatch::Consumed,
+            "held Right repeat is debounced for focused sessions"
         );
 
         dispatch_global_key(key(KeyCode::Char('x')), &mut state);
@@ -10611,25 +10583,25 @@ mod tests {
         state.focus = crate::chat::sessions::FocusTarget::Transcript;
         assert_eq!(
             dispatch_global_key(key(KeyCode::Right), &mut state),
-            KeyDispatch::Consumed,
-            "transcript focus must not switch to real sessions with Right"
+            KeyDispatch::SwitchSession { seq: 1 },
+            "transcript focus can switch to bottom entries with Right"
         );
         assert_eq!(
             dispatch_global_key(key(KeyCode::Left), &mut state),
-            KeyDispatch::Consumed,
-            "transcript focus must not switch to real sessions with Left"
+            KeyDispatch::SwitchSession { seq: 3 },
+            "transcript focus can switch to bottom entries with Left"
         );
 
         state.focus = crate::chat::sessions::FocusTarget::Diff;
         assert_eq!(
             dispatch_global_key(key(KeyCode::Right), &mut state),
-            KeyDispatch::Consumed,
-            "diff focus must not switch to real sessions with Right"
+            KeyDispatch::SwitchSession { seq: 1 },
+            "diff focus can switch to bottom entries with Right"
         );
         assert_eq!(
             dispatch_global_key(key(KeyCode::Left), &mut state),
-            KeyDispatch::Consumed,
-            "diff focus must not switch to real sessions with Left"
+            KeyDispatch::SwitchSession { seq: 3 },
+            "diff focus can switch to bottom entries with Left"
         );
 
         dispatch_global_key(key_mod(KeyCode::Char('g'), KeyModifiers::CONTROL), &mut state);
@@ -10642,21 +10614,16 @@ mod tests {
     }
 
     #[test]
-    fn bottom_directional_selection_skips_completed_history_rows() {
+    fn bottom_directional_switch_skips_completed_history_rows() {
         let mut state = TuiState::new("p", "m");
         let mut completed = entry(1);
         completed.status = "completed";
         state.sessions_cache = vec![completed, entry(2)];
 
         assert_eq!(
-            dispatch_global_key(key(KeyCode::Down), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(2) },
-            "bare Down should select the first active child, not completed history"
-        );
-        assert_eq!(
-            dispatch_global_key(key(KeyCode::Enter), &mut state),
+            dispatch_global_key(key(KeyCode::Right), &mut state),
             KeyDispatch::AttachSession { seq: 2 },
-            "Enter attaches the visible active child"
+            "bare Right should attach the first active child, not completed history"
         );
 
         let mut history_only = TuiState::new("p", "m");
@@ -10703,81 +10670,22 @@ mod tests {
         }
     }
 
-    fn kind_entry(seq: u64, kind: &'static str) -> crate::chat::sessions::SwitcherEntry {
-        let mut entry = entry(seq);
-        entry.kind = kind;
-        entry
-    }
-
     #[test]
-    fn alt_arrows_move_ui_only_strip_selection_without_focus_change() {
+    fn alt_arrows_do_not_change_bottom_focus() {
         let mut state = TuiState::new("p", "m");
         state.sessions_cache = vec![entry(1), entry(2), entry(3)];
 
-        assert_eq!(
-            dispatch_global_key(key_mod(KeyCode::Right, KeyModifiers::ALT), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(1) }
-        );
-        assert_eq!(state.strip_selection, Some(1));
-        assert_eq!(state.focus, crate::chat::sessions::FocusTarget::Main);
-
-        assert_eq!(
-            dispatch_global_key(key_mod(KeyCode::Right, KeyModifiers::ALT), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(2) }
-        );
-        assert_eq!(
-            dispatch_global_key(key_mod(KeyCode::Left, KeyModifiers::ALT), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(1) }
-        );
-        assert_eq!(
-            dispatch_global_key(key_mod(KeyCode::Up, KeyModifiers::ALT), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(3) }
-        );
-        assert_eq!(
-            dispatch_global_key(key_mod(KeyCode::Down, KeyModifiers::ALT), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(1) }
-        );
-        assert_eq!(
-            state.focus,
-            crate::chat::sessions::FocusTarget::Main,
-            "strip selection must not change input-routing focus"
-        );
-    }
-
-    #[test]
-    fn alt_arrows_seed_from_focused_session_when_no_strip_selection_exists() {
-        let mut state = TuiState::new("p", "m");
-        state.sessions_cache = vec![entry(1), entry(2), entry(3)];
-        state.focus = crate::chat::sessions::FocusTarget::Session { seq: 2 };
-
-        assert_eq!(
-            dispatch_global_key(key_mod(KeyCode::Right, KeyModifiers::ALT), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(3) }
-        );
-        assert_eq!(state.focus, crate::chat::sessions::FocusTarget::Session { seq: 2 });
-    }
-
-    #[test]
-    fn alt_enter_attaches_selected_strip_entry_for_all_session_kinds() {
-        for (seq, kind) in [(1, "agent"), (2, "shell"), (3, "pty")] {
-            let mut state = TuiState::new("p", "m");
-            state.sessions_cache = vec![kind_entry(seq, kind)];
-            state.strip_selection = Some(seq);
-
+        for code in [KeyCode::Left, KeyCode::Right, KeyCode::Up, KeyCode::Down] {
             assert_eq!(
-                dispatch_global_key(key_mod(KeyCode::Enter, KeyModifiers::ALT), &mut state),
-                KeyDispatch::AttachSession { seq },
-                "Alt+Enter reuses the single attach dispatch for {kind}"
-            );
-            assert_eq!(
-                state.strip_selection, None,
-                "Alt+Enter attach consumes the UI-only strip selection for {kind}"
+                dispatch_global_key(key_mod(code, KeyModifiers::ALT), &mut state),
+                KeyDispatch::Consumed
             );
         }
+        assert_eq!(state.focus, crate::chat::sessions::FocusTarget::Main);
     }
 
     #[test]
-    fn alt_enter_without_strip_selection_falls_through_to_newline_insert() {
+    fn alt_enter_still_inserts_newline() {
         let mut state = TuiState::new("p", "m");
         state.sessions_cache = vec![entry(1)];
         dispatch_global_key(key(KeyCode::Char('a')), &mut state);
@@ -10800,51 +10708,36 @@ mod tests {
     }
 
     #[test]
-    fn alt_enter_stale_strip_selection_is_consumed_with_session_gone_status() {
+    fn alt_enter_does_not_attach_bottom_entry() {
         let mut state = TuiState::new("p", "m");
         state.sessions_cache = vec![entry(1)];
-        state.strip_selection = Some(2);
         dispatch_global_key(key(KeyCode::Char('a')), &mut state);
 
         assert_eq!(
             dispatch_global_key(key_mod(KeyCode::Enter, KeyModifiers::ALT), &mut state),
             KeyDispatch::Consumed
         );
-        assert_eq!(state.strip_selection, None);
-        assert_eq!(state.input.text(), "a", "stale Alt+Enter must not insert a newline");
-        assert!(
-            matches!(
-                state.conversation_lines.last(),
-                Some(ConversationLine::System { content }) if content == "session gone"
-            ),
-            "stale selection should surface a status message"
-        );
+        assert_eq!(state.input.text(), "a\n", "Alt+Enter remains a newline chord");
+        assert!(state.conversation_lines.is_empty());
     }
 
     #[test]
-    fn esc_clears_strip_selection_before_normal_cancel_or_detach() {
+    fn esc_keeps_normal_cancel_or_detach_semantics() {
         let mut state = TuiState::new("p", "m");
         state.sessions_cache = vec![entry(1)];
-        state.strip_selection = Some(1);
         dispatch_global_key(key(KeyCode::Char('x')), &mut state);
 
         assert_eq!(
             dispatch_global_key(key(KeyCode::Esc), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: None }
+            KeyDispatch::Cancelled
         );
-        assert_eq!(state.strip_selection, None);
-        assert_eq!(
-            state.input.text(),
-            "x",
-            "Esc clears strip highlight before touching input"
-        );
+        assert_eq!(state.input.text(), "", "Esc now follows normal input cancel semantics");
     }
 
     #[test]
-    fn bare_arrows_history_cursor_and_child_scroll_are_not_stolen_by_strip_selection() {
+    fn bare_arrows_scroll_transcript_and_child_views_not_history() {
         let mut state = TuiState::new("p", "m");
         state.sessions_cache = vec![entry(1), entry(2)];
-        state.strip_selection = Some(2);
         dispatch_global_key(key(KeyCode::Char('a')), &mut state);
         assert_eq!(
             dispatch_global_key(key(KeyCode::Enter), &mut state),
@@ -10853,19 +10746,17 @@ mod tests {
 
         assert_eq!(
             dispatch_global_key(key(KeyCode::Up), &mut state),
-            KeyDispatch::StripSelectionChanged { selected: Some(1) },
-            "Contract B: with strip entries present, bare Up navigates the strip"
+            KeyDispatch::ScrollTranscriptUp,
+            "main+empty bare Up scrolls transcript even with bottom entries present"
         );
-        assert!(state.input.is_empty(), "strip navigation must not recall history");
-        assert_eq!(state.strip_selection, Some(1));
+        assert!(state.input.is_empty(), "bare Up must not recall history");
 
         state.sessions_cache.clear();
-        assert_eq!(dispatch_global_key(key(KeyCode::Up), &mut state), KeyDispatch::Consumed);
         assert_eq!(
-            state.input.text(),
-            "a",
-            "when strip entries are absent, bare Up still recalls input history"
+            dispatch_global_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL), &mut state),
+            KeyDispatch::Consumed
         );
+        assert_eq!(state.input.text(), "a", "Ctrl+P recalls input history");
 
         assert_eq!(
             dispatch_global_key(key(KeyCode::Left), &mut state),
@@ -10897,16 +10788,14 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_g_still_opens_switcher_when_strip_selection_exists() {
+    fn ctrl_g_still_opens_switcher() {
         let mut state = TuiState::new("p", "m");
         state.sessions_cache = vec![entry(1), entry(2)];
-        state.strip_selection = Some(2);
 
         let out = dispatch_global_key(key_mod(KeyCode::Char('g'), KeyModifiers::CONTROL), &mut state);
 
         assert!(matches!(out, KeyDispatch::SwitcherOpened { .. }));
         assert!(state.switcher.is_some(), "Ctrl+G modal remains available");
-        assert_eq!(state.strip_selection, Some(2), "modal does not reuse routing focus");
     }
 
     fn usage_record(
@@ -11137,32 +11026,23 @@ mod tests {
     }
 
     #[test]
-    fn sessions_strip_selection_beyond_initial_window_is_visible_and_highlighted() {
+    fn sessions_strip_active_entry_beyond_initial_window_is_visible_and_marked() {
         let entries = long_strip_entries(8);
         let line = render_sessions_strip_styled_line(
             &entries,
             "",
-            crate::chat::sessions::FocusTarget::Main,
-            Some(8),
+            crate::chat::sessions::FocusTarget::Session { seq: 8 },
             false,
             58,
         );
         let plain = line_to_plain(&line);
 
-        assert!(plain.contains("#8"), "selected seq is windowed into view: {plain}");
+        assert!(plain.contains("#8"), "active seq is windowed into view: {plain}");
         assert!(
             plain.contains('\u{2039}'),
             "leading overflow indicator appears: {plain}"
         );
-
-        let selected = line
-            .spans
-            .iter()
-            .find(|span| span.content.contains("#8"))
-            .expect("test: selected span");
-        assert_eq!(selected.style.bg, Some(Color::Cyan));
-        assert_eq!(selected.style.fg, Some(Color::Black));
-        assert!(selected.style.add_modifier.contains(Modifier::BOLD));
+        assert!(plain.contains('\u{25B8}'), "active marker remains visible: {plain}");
     }
 
     #[test]
@@ -11184,16 +11064,15 @@ mod tests {
     #[test]
     fn sessions_strip_overflow_indicator_has_ascii_fallback() {
         let entries = long_strip_entries(8);
-        let line = render_sessions_strip_line_with_selection(
+        let line = render_sessions_strip_line(
             &entries,
             "",
-            crate::chat::sessions::FocusTarget::Main,
-            Some(3),
+            crate::chat::sessions::FocusTarget::Session { seq: 3 },
             true,
             58,
         );
 
-        assert!(line.contains("#3"), "selected seq is visible in ASCII mode: {line}");
+        assert!(line.contains("#3"), "active seq is visible in ASCII mode: {line}");
         assert!(
             line.contains('>') && line.contains('+'),
             "ASCII right overflow/count affordance appears when entries remain hidden: {line}"
@@ -11282,12 +11161,11 @@ mod tests {
         let rows = lines.iter().map(line_to_plain).collect::<Vec<_>>();
 
         assert!(
-            rows.iter()
-                .any(|row| row.contains("↑↓ sessions") && row.contains("Enter attach/open")),
-            "session footer should expose arrow navigation and Enter behavior: {rows:?}"
+            rows.iter().any(|row| row.contains("←/→ session")),
+            "session footer should expose horizontal session navigation: {rows:?}"
         );
         assert!(
-            footer_text(false, true).contains("↑↓ sessions"),
+            footer_text(false, true).contains("←/→ session") && footer_text(false, true).contains("Ctrl+P/N history"),
             "static footer text helper also includes the dynamic hint"
         );
     }
@@ -11340,25 +11218,23 @@ mod tests {
     #[test]
     fn sessions_strip_zero_width_and_one_entry_edge_cases_do_not_panic() {
         let entries = long_strip_entries(1);
-        let empty = render_sessions_strip_line_with_selection(
+        let empty = render_sessions_strip_line(
             &entries,
             "",
             crate::chat::sessions::FocusTarget::Session { seq: 1 },
-            Some(1),
             false,
             0,
         );
         assert!(empty.is_empty());
 
-        let one = render_sessions_strip_line_with_selection(
+        let one = render_sessions_strip_line(
             &entries,
             "",
             crate::chat::sessions::FocusTarget::Session { seq: 1 },
-            Some(1),
             false,
             18,
         );
-        assert!(one.contains("#1"), "single selected chip still renders: {one}");
+        assert!(one.contains("#1"), "single active chip still renders: {one}");
         assert!(
             UnicodeWidthStr::width(one.as_str()) <= 18,
             "single-chip strip must fit narrow width: {one}"
@@ -11366,28 +11242,18 @@ mod tests {
     }
 
     #[test]
-    fn sessions_strip_selected_entry_is_highlighted_separately_from_focus() {
+    fn sessions_strip_focus_drives_active_marker_without_selection_highlight() {
         let entries = vec![entry(1), entry(2)];
         let line = render_sessions_strip_styled_line(
             &entries,
             "",
             crate::chat::sessions::FocusTarget::Session { seq: 1 },
-            Some(2),
             false,
             96,
         );
         let plain = line_to_plain(&line);
         assert!(plain.contains("#1"), "focused entry remains visible: {plain}");
-        assert!(plain.contains("#2"), "selected entry remains visible: {plain}");
-
-        let selected = line
-            .spans
-            .iter()
-            .find(|span| span.content.contains("#2"))
-            .expect("test: selected span");
-        assert_eq!(selected.style.bg, Some(Color::Cyan));
-        assert_eq!(selected.style.fg, Some(Color::Black));
-        assert!(selected.style.add_modifier.contains(Modifier::BOLD));
+        assert!(plain.contains("#2"), "neighbor entry remains visible: {plain}");
 
         let focused = line
             .spans
@@ -11398,6 +11264,7 @@ mod tests {
             focused.style.bg, None,
             "input-routing focus uses the active marker, not selected highlight"
         );
+        assert!(plain.contains('\u{25B8}'), "focused entry has active marker: {plain}");
     }
 
     #[test]
@@ -11696,7 +11563,7 @@ mod tests {
     }
 
     #[test]
-    fn phase2_bottom_direction_selects_provider_worker_and_enter_opens_worker_view() {
+    fn phase2_bottom_direction_opens_provider_worker_view_immediately() {
         let mut state = TuiState::new("p", "m");
         state.provider_worker_status = provider_worker_status_fixture();
         state.visible_streaming_drafts = Arc::new(vec![crate::chat::state::VisibleStreamingDraftView {
@@ -11707,14 +11574,7 @@ mod tests {
                 version: 1,
             },
         }]);
-        let out = dispatch_global_key(key(KeyCode::Down), &mut state);
-        assert_eq!(
-            out,
-            KeyDispatch::StripSelectionChanged {
-                selected: Some(PROVIDER_WORKER_SWITCHER_SEQ_BASE + 3)
-            }
-        );
-        let out = dispatch_global_key(key(KeyCode::Enter), &mut state);
+        let out = dispatch_global_key(key(KeyCode::Right), &mut state);
         assert_eq!(out, KeyDispatch::OpenProviderWorkerView { sequence: 3 });
         assert_eq!(
             state
@@ -11728,7 +11588,6 @@ mod tests {
                 .is_none(),
             "synthetic switcher seq must not be used for draft lookup"
         );
-        assert_eq!(state.strip_selection, None);
     }
 
     #[test]
@@ -11757,8 +11616,10 @@ mod tests {
         state.sessions_cache = vec![entry(7)];
         state.focus = crate::chat::sessions::FocusTarget::Worker { sequence: 3 };
         let out = dispatch_global_key(key(KeyCode::Up), &mut state);
-        assert_eq!(out, KeyDispatch::CloseProviderWorkerView);
+        assert_eq!(out, KeyDispatch::ScrollSessionUp);
         let out = dispatch_global_key(key(KeyCode::Down), &mut state);
+        assert_eq!(out, KeyDispatch::ScrollSessionDown);
+        let out = dispatch_global_key(key(KeyCode::Right), &mut state);
         assert_eq!(out, KeyDispatch::SwitchSession { seq: 7 });
         let out = dispatch_global_key(key(KeyCode::Esc), &mut state);
         assert_eq!(out, KeyDispatch::CloseProviderWorkerView);
@@ -12167,8 +12028,7 @@ mod tests {
             "bottom list should show the running task title, not shortcut-only chrome: {rows:?}"
         );
         assert!(
-            rows.iter()
-                .any(|row| row.contains("↑↓ sessions") && row.contains("Enter attach/open")),
+            rows.iter().any(|row| row.contains("←/→ session")),
             "session list footer should expose navigation hint: {rows:?}"
         );
         assert!(
@@ -12829,12 +12689,11 @@ mod tests {
         let mut history_state = TuiState::new("provider", "model");
         history_state.input.history = vec!["older".to_string(), "newer".to_string()];
         let out = dispatch_global_key(key(KeyCode::Up), &mut history_state);
+        assert_eq!(out, KeyDispatch::ScrollTranscriptUp);
+        assert!(history_state.input.is_empty());
+        let out = dispatch_global_key(key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL), &mut history_state);
         assert_eq!(out, KeyDispatch::Consumed);
-        assert_eq!(
-            history_state.input.text(),
-            "newer",
-            "Up still navigates input history and is not a transcript-scroll key"
-        );
+        assert_eq!(history_state.input.text(), "newer", "Ctrl+P navigates input history");
 
         let mut strip_state = TuiState::new("provider", "model");
         strip_state.sessions_cache = vec![entry(1)];
@@ -12842,8 +12701,8 @@ mod tests {
         let out = dispatch_global_key(key(KeyCode::Down), &mut strip_state);
         assert_eq!(
             out,
-            KeyDispatch::StripSelectionChanged { selected: Some(1) },
-            "Contract B: strip entries make bare arrows navigate the strip before input history"
+            KeyDispatch::ScrollTranscriptDown,
+            "bottom entries do not steal bare Down from transcript scrolling"
         );
         assert!(strip_state.input.is_empty());
 
@@ -13499,7 +13358,6 @@ mod tests {
                 idle_warning: false,
             };
             state.ui.sessions_entries = vec![session_entry.clone()];
-            state.ui.strip_selection = Some(7);
             state.ui.context_used_tokens = Some(2_500);
             state.ui.context_window_tokens = Some(10_000_000);
             state.ui.chat_mode = ChatMode::Auto;
@@ -13532,7 +13390,6 @@ mod tests {
             tui.streaming = state.stream.primary_streaming_draft().cloned();
             tui.input = state.ui.input.clone();
             tui.sessions_cache = vec![session_entry];
-            tui.strip_selection = Some(7);
             tui.chat_mode = ChatMode::Auto;
             tui.autonomy_level = AutonomyLevel::ReadOnly;
             tui.focus = crate::chat::sessions::FocusTarget::Diff;
@@ -13581,10 +13438,6 @@ mod tests {
                 BottomChromeView::active_session_view(&snap)
             );
             assert_eq!(BottomChromeView::focus(&tui), BottomChromeView::focus(&snap));
-            assert_eq!(
-                BottomChromeView::strip_selection(&tui),
-                BottomChromeView::strip_selection(&snap)
-            );
             assert_eq!(
                 BottomChromeView::pending_tool_approval(&tui),
                 BottomChromeView::pending_tool_approval(&snap)

--- a/src/chat/tui.rs
+++ b/src/chat/tui.rs
@@ -1077,6 +1077,12 @@ fn provider_worker_switcher_entry(row: &ProviderWorkerStatusRow) -> crate::chat:
         title.push_str(" tokens=");
         title.push_str(&format_worker_tokens_compact(tokens));
     }
+    if row.is_active()
+        && let Some(summary) = row.recent_tool_call.as_deref().filter(|summary| !summary.is_empty())
+    {
+        title.push_str(" · ");
+        title.push_str(summary);
+    }
     crate::chat::sessions::SwitcherEntry {
         seq: PROVIDER_WORKER_SWITCHER_SEQ_BASE.saturating_add(row.sequence),
         kind: PROVIDER_WORKER_SWITCHER_KIND,
@@ -1298,6 +1304,59 @@ fn provider_worker_io_clip(text: &str) -> String {
     truncate_chars_with_ellipsis(text.trim(), PROVIDER_WORKER_IO_LINE_MAX_CHARS, false)
 }
 
+const PROVIDER_WORKER_TITLE_TOOL_MAX_CHARS: u16 = 64;
+
+#[must_use]
+pub fn latest_provider_worker_tool_summary_from_conversation(
+    conversation: &[ConversationLine],
+    ascii: bool,
+) -> Option<String> {
+    conversation
+        .iter()
+        .rev()
+        .take(PROVIDER_WORKER_IO_MAX_SOURCE_ITEMS)
+        .find_map(|item| match item {
+            ConversationLine::ToolResult {
+                tool_name,
+                args_preview,
+                args_full,
+                status,
+                ..
+            } => {
+                let args = if args_preview.trim().is_empty() {
+                    args_full
+                } else {
+                    args_preview
+                };
+                let summary = format!(
+                    "run {} {}: {}",
+                    tool_name,
+                    tool_status_name(*status),
+                    provider_worker_io_clip(args)
+                );
+                Some(truncate_chars_with_ellipsis(
+                    &summary,
+                    PROVIDER_WORKER_TITLE_TOOL_MAX_CHARS,
+                    ascii,
+                ))
+            }
+            ConversationLine::Tool { name, success } => {
+                let status = if *success { "done" } else { "error" };
+                let summary = format!("run {name} {status}");
+                Some(truncate_chars_with_ellipsis(
+                    &summary,
+                    PROVIDER_WORKER_TITLE_TOOL_MAX_CHARS,
+                    ascii,
+                ))
+            }
+            ConversationLine::User { .. }
+            | ConversationLine::Assistant { .. }
+            | ConversationLine::StreamingAssistant { .. }
+            | ConversationLine::System { .. }
+            | ConversationLine::Reasoning { .. } => None,
+        })
+}
+
 /// Build compact live IO lines for the read-only provider worker detail view.
 ///
 /// This is intentionally derived from the same conversation/tool cards the main
@@ -1517,6 +1576,26 @@ pub fn dispatch_global_key(key: KeyEvent, state: &mut TuiState) -> KeyDispatch {
                     return KeyDispatch::ToolApprovalDecision {
                         tool_id: pending.tool_id,
                         approved: false,
+                    };
+                }
+                KeyCode::Left | KeyCode::Up => {
+                    if let Some(pending) = state.pending_tool_approval.as_mut() {
+                        pending.selected_approval = false;
+                    }
+                    return KeyDispatch::Consumed;
+                }
+                KeyCode::Right | KeyCode::Down => {
+                    if let Some(pending) = state.pending_tool_approval.as_mut() {
+                        pending.selected_approval = true;
+                    }
+                    return KeyDispatch::Consumed;
+                }
+                KeyCode::Enter => {
+                    state.pending_tool_approval = None;
+                    state.focus = crate::chat::sessions::FocusTarget::Main;
+                    return KeyDispatch::ToolApprovalDecision {
+                        tool_id: pending.tool_id,
+                        approved: pending.selected_approval,
                     };
                 }
                 _ => return KeyDispatch::Consumed,
@@ -3303,6 +3382,11 @@ impl TuiState {
         execution_activity_active_for_view(self)
     }
 
+    #[must_use]
+    pub fn periodic_redraw_active(&self) -> bool {
+        periodic_redraw_active_for_view(self)
+    }
+
     /// Replace the persistent child-session status line (v1b).
     ///
     /// An empty `summary` hides the extra status row entirely.
@@ -4014,7 +4098,7 @@ fn session_footer_desired_rows<V: BottomChromeView + ?Sized>(state: &V) -> u16 {
     } else if visible_entries.is_empty() {
         1
     } else {
-        visible_entries.len().saturating_add(1)
+        visible_entries.len().saturating_add(2)
     };
     u16::try_from(rows).unwrap_or(u16::MAX).max(1)
 }
@@ -4248,7 +4332,14 @@ fn render_fullscreen_panel<V: BottomChromeView + ?Sized>(frame: &mut Frame, area
     };
     frame.render_widget(Clear, area);
     if let Some(approval) = state.pending_tool_approval() {
-        render_approval(frame, area, &approval.name, &approval.args, state.ascii_fallback());
+        render_approval(
+            frame,
+            area,
+            &approval.name,
+            &approval.args,
+            approval.selected_approval,
+            state.ascii_fallback(),
+        );
     } else if let Some(view) = state.active_session_view() {
         render_active_session_view(frame, area, view, state.ascii_fallback());
     }
@@ -4419,13 +4510,37 @@ const fn session_active_marker(active: bool, ascii: bool) -> &'static str {
     }
 }
 
-fn session_status_glyph(entry: &crate::chat::sessions::SwitcherEntry, ascii: bool) -> &'static str {
+const SPINNER_FRAME_MS: u64 = 150;
+const ASCII_SPINNER_FRAMES: [&str; 4] = ["-", "\\", "|", "/"];
+const UNICODE_SPINNER_FRAMES: [&str; 4] = ["⠋", "⠙", "⠹", "⠸"];
+
+fn current_animation_tick() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| {
+            u64::try_from(duration.as_millis() / u128::from(SPINNER_FRAME_MS)).unwrap_or(u64::MAX)
+        })
+}
+
+fn spinner_frame_for_tick(ascii: bool, tick: u64) -> &'static str {
+    let frames = if ascii {
+        &ASCII_SPINNER_FRAMES
+    } else {
+        &UNICODE_SPINNER_FRAMES
+    };
+    let idx = usize::try_from(tick % u64::try_from(frames.len()).unwrap_or(1)).unwrap_or(0);
+    frames.get(idx).copied().unwrap_or("-")
+}
+
+fn session_status_glyph_for_tick(entry: &crate::chat::sessions::SwitcherEntry, ascii: bool, tick: u64) -> &'static str {
     if entry.is_transcript() {
         return if ascii { "[T]" } else { "T" };
     }
+    if entry.status == "running" {
+        return spinner_frame_for_tick(ascii, tick);
+    }
     if ascii {
         match entry.status {
-            "running" => "[~]",
             "needs-input" => "[?]",
             "completed" => "[x]",
             "cancelled" => "[-]",
@@ -4434,6 +4549,10 @@ fn session_status_glyph(entry: &crate::chat::sessions::SwitcherEntry, ascii: boo
     } else {
         entry.status_glyph()
     }
+}
+
+fn session_status_glyph(entry: &crate::chat::sessions::SwitcherEntry, ascii: bool) -> &'static str {
+    session_status_glyph_for_tick(entry, ascii, current_animation_tick())
 }
 
 const SESSION_STRIP_CHIP_MAX_WIDTH: u16 = 24;
@@ -4507,6 +4626,7 @@ fn render_sessions_list_entry_line(
     let active = active_seq == Some(entry.seq);
     let selected = strip_selection == Some(entry.seq);
     let marker = session_active_marker(active, ascii);
+    let glyph = session_status_glyph(entry, ascii);
     let idle = if entry.idle_warning {
         if ascii { " [idle]" } else { " ⚠ idle" }
     } else {
@@ -4519,7 +4639,7 @@ fn render_sessions_list_entry_line(
     let sep = if ascii { " | " } else { " · " };
     let display_id = switcher_entry_display_id(entry);
     let prefix = format!(
-        "{marker} {display_id} {} {} {}{}{}{}",
+        "{marker}{glyph} {display_id} {} {} {}{}{}{}",
         entry.kind,
         entry.origin,
         entry.status,
@@ -4578,6 +4698,19 @@ fn render_main_session_list_line<V: BottomChromeView + ?Sized>(state: &V, width:
     Line::from(Span::styled(text, style))
 }
 
+const fn sessions_navigation_hint(ascii: bool) -> &'static str {
+    if ascii {
+        " Up/Down sessions | Enter attach/open "
+    } else {
+        " \u{2191}\u{2193} sessions \u{00B7} Enter attach/open "
+    }
+}
+
+fn render_sessions_navigation_hint_line(ascii: bool, width: u16) -> Line<'static> {
+    let text = truncate_chars_with_ellipsis(sessions_navigation_hint(ascii), width, ascii);
+    Line::from(Span::styled(text, Style::default().fg(Color::DarkGray)))
+}
+
 fn render_sessions_list_lines<V: BottomChromeView + ?Sized>(
     state: &V,
     width: u16,
@@ -4600,14 +4733,15 @@ fn render_sessions_list_lines<V: BottomChromeView + ?Sized>(
     }
     let active_seq = focus_active_entry_seq(focus);
     let total = entries.len().saturating_add(1);
+    let list_rows = max_rows.saturating_sub(1).max(1);
     let target_idx = bottom_list_selection_index(&entries, strip_selection, focus).min(total.saturating_sub(1));
-    let start = if total <= max_rows {
+    let start = if total <= list_rows {
         0
     } else {
-        target_idx.saturating_add(1).saturating_sub(max_rows)
+        target_idx.saturating_add(1).saturating_sub(list_rows)
     };
     let mut lines = Vec::new();
-    for idx in start..total.min(start.saturating_add(max_rows)) {
+    for idx in start..total.min(start.saturating_add(list_rows)) {
         if idx == 0 {
             lines.push(render_main_session_list_line(state, width));
         } else if let Some(entry) = entries.get(idx.saturating_sub(1)) {
@@ -4619,6 +4753,9 @@ fn render_sessions_list_lines<V: BottomChromeView + ?Sized>(
                 width,
             ));
         }
+    }
+    if lines.len() < max_rows {
+        lines.push(render_sessions_navigation_hint_line(ascii, width));
     }
     lines
 }
@@ -5465,18 +5602,7 @@ fn render_generation_activity<V: BottomChromeView + ?Sized>(state: &V) -> Option
     if !execution_activity_active_for_view(state) {
         return None;
     }
-    let frames = if state.ascii_fallback() {
-        ["-", "\\", "|", "/"]
-    } else {
-        ["⠋", "⠙", "⠹", "⠸"]
-    };
-    let tick = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |duration| {
-            u64::try_from(duration.as_millis() / 50).unwrap_or(u64::MAX)
-        });
-    let idx = usize::try_from(tick % u64::try_from(frames.len()).unwrap_or(1)).unwrap_or(0);
-    let frame = frames.get(idx).copied().unwrap_or("-");
+    let frame = spinner_frame_for_tick(state.ascii_fallback(), current_animation_tick());
     Some(format!("{frame} generating (esc to interrupt)"))
 }
 
@@ -5624,6 +5750,16 @@ pub fn execution_activity_active_for_view<V: BottomChromeView + ?Sized>(state: &
                 }
             )
         })
+}
+
+pub fn bottom_running_entry_active_for_view<V: BottomChromeView + ?Sized>(state: &V) -> bool {
+    bottom_chrome_session_entries_with_workers(state.sessions_entries(), state.provider_worker_status(), state.focus())
+        .iter()
+        .any(|entry| entry.status == "running")
+}
+
+pub fn periodic_redraw_active_for_view<V: BottomChromeView + ?Sized>(state: &V) -> bool {
+    execution_activity_active_for_view(state) || bottom_running_entry_active_for_view(state)
 }
 
 fn render_permission_status(mode: ChatMode, autonomy: AutonomyLevel) -> String {
@@ -6998,15 +7134,30 @@ fn render_input<V: BottomChromeView + ?Sized>(frame: &mut Frame, area: Rect, sta
     }
 }
 
-fn render_footer(frame: &mut Frame, area: Rect) {
+fn footer_text(ascii: bool, show_session_hint: bool) -> String {
     // Claude Code style: dim gray, middle-dot separators, action-oriented
     // hints rather than key/label pairs.
     // P6b2: Ctrl+G remains PRX's sessions switcher; Claude-style external
     // editor parity is available through the alternate Ctrl+X Ctrl+E chord.
-    let footer = Paragraph::new(
-        " Ctrl+G sessions \u{00B7} Ctrl+O transcript \u{00B7} /copy latest \u{00B7} drag select/copy \u{00B7} Shift+Enter newline \u{00B7} Ctrl+X Ctrl+E edit \u{00B7} Tab fold \u{00B7} Esc cancel ",
-    )
-    .style(Style::default().fg(Color::DarkGray));
+    let sep = if ascii { " | " } else { " \u{00B7} " };
+    let mut parts = Vec::from([
+        "Ctrl+G sessions",
+        "Ctrl+O transcript",
+        "/copy latest",
+        "drag select/copy",
+        "Shift+Enter newline",
+        "Ctrl+X Ctrl+E edit",
+        "Tab fold",
+        "Esc cancel",
+    ]);
+    if show_session_hint {
+        parts.insert(1, sessions_navigation_hint(ascii).trim());
+    }
+    format!(" {} ", parts.join(sep))
+}
+
+fn render_footer(frame: &mut Frame, area: Rect, ascii: bool, show_session_hint: bool) {
+    let footer = Paragraph::new(footer_text(ascii, show_session_hint)).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(footer, area);
 }
 
@@ -7041,15 +7192,41 @@ fn render_fullscreen_footer<V: BottomChromeView + ?Sized>(
     if render_session_list_footer(frame, area, state) {
         return;
     }
-    render_footer(frame, area);
+    render_footer(frame, area, state.ascii_fallback(), session_footer_has_sessions(state));
 }
 
 /// Render a tool approval prompt.
-pub fn render_approval(frame: &mut Frame, area: Rect, tool_name: &str, args: &str, ascii: bool) {
+pub fn render_approval(
+    frame: &mut Frame,
+    area: Rect,
+    tool_name: &str,
+    args: &str,
+    selected_approval: bool,
+    ascii: bool,
+) {
     if area.height == 0 || area.width == 0 {
         return;
     }
     let marker = if ascii { ">" } else { "\u{25B8}" };
+    let approve_marker = if selected_approval { marker } else { " " };
+    let deny_marker = if selected_approval { " " } else { marker };
+    let approve_style = if selected_approval {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Green)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+    };
+    let deny_style = if selected_approval {
+        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Red)
+            .add_modifier(Modifier::BOLD)
+    };
+    let select_hint = if ascii { "Left/Right" } else { "\u{2190}/\u{2192}" };
     let approval_text = vec![
         Line::from(vec![
             Span::styled(
@@ -7064,18 +7241,28 @@ pub fn render_approval(frame: &mut Frame, area: Rect, tool_name: &str, args: &st
         ]),
         Line::from(""),
         Line::from(vec![
-            Span::styled("[y]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled(format!("{approve_marker} [y]"), approve_style),
             Span::raw(" approve  "),
-            Span::styled("[n]", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+            Span::styled(format!("{deny_marker} [n]"), deny_style),
             Span::raw(" deny  "),
             Span::styled("[Esc]", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
             Span::raw(" deny"),
         ]),
+        Line::from(Span::styled(
+            format!("{select_hint} select · Enter confirm"),
+            Style::default().fg(Color::DarkGray),
+        )),
     ];
 
+    let selected_label = if selected_approval { "approve" } else { "deny" };
+    let title = if ascii {
+        format!(" Tool Approval - selected: {selected_label} - Left/Right select - Enter confirm ")
+    } else {
+        format!(" Tool Approval - selected: {selected_label} - ←/→ select - Enter confirm ")
+    };
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(" Tool Approval ")
+        .title(title)
         .border_style(Style::default().fg(Color::Yellow));
 
     let paragraph = Paragraph::new(approval_text).block(block).wrap(Wrap { trim: false });
@@ -9917,6 +10104,7 @@ mod tests {
             tool_id: "call-1".to_string(),
             name: "shell".to_string(),
             args: r#"{"cmd":"echo hi"}"#.to_string(),
+            selected_approval: false,
         });
         state
     }
@@ -9954,18 +10142,83 @@ mod tests {
     }
 
     #[test]
-    fn approval_child_text_enter_does_not_submit_or_steer() {
-        for key_event in [key(KeyCode::Char('x')), key(KeyCode::Enter)] {
-            let mut state = approval_state();
-            let out = dispatch_global_key(key_event, &mut state);
-            assert_eq!(out, KeyDispatch::Consumed);
-            assert!(state.input.is_empty(), "approval focus must not edit the main input");
-            assert!(
-                state.pending_tool_approval.is_some(),
-                "text/Enter must not close approval"
-            );
-            assert_eq!(state.focus, crate::chat::sessions::FocusTarget::Approval);
-        }
+    fn approval_child_text_does_not_submit_or_steer() {
+        let mut state = approval_state();
+        let out = dispatch_global_key(key(KeyCode::Char('x')), &mut state);
+        assert_eq!(out, KeyDispatch::Consumed);
+        assert!(state.input.is_empty(), "approval focus must not edit the main input");
+        assert!(
+            state.pending_tool_approval.is_some(),
+            "plain text must not close approval"
+        );
+        assert_eq!(state.focus, crate::chat::sessions::FocusTarget::Approval);
+    }
+
+    #[test]
+    fn approval_child_arrows_select_and_enter_confirms() {
+        let mut state = approval_state();
+        assert!(
+            !state
+                .pending_tool_approval
+                .as_ref()
+                .expect("approval starts pending")
+                .selected_approval,
+            "approval defaults to the safe deny choice"
+        );
+
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Right), &mut state),
+            KeyDispatch::Consumed
+        );
+        assert!(
+            state
+                .pending_tool_approval
+                .as_ref()
+                .expect("approval remains pending after navigation")
+                .selected_approval,
+            "Right selects approve"
+        );
+        let out = dispatch_global_key(key(KeyCode::Enter), &mut state);
+        assert_eq!(
+            out,
+            KeyDispatch::ToolApprovalDecision {
+                tool_id: "call-1".to_string(),
+                approved: true
+            }
+        );
+        assert!(state.pending_tool_approval.is_none());
+        assert_eq!(state.focus, crate::chat::sessions::FocusTarget::Main);
+    }
+
+    #[test]
+    fn approval_child_enter_uses_default_deny_and_left_selects_deny() {
+        let mut default_state = approval_state();
+        let out = dispatch_global_key(key(KeyCode::Enter), &mut default_state);
+        assert_eq!(
+            out,
+            KeyDispatch::ToolApprovalDecision {
+                tool_id: "call-1".to_string(),
+                approved: false
+            }
+        );
+
+        let mut state = approval_state();
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Right), &mut state),
+            KeyDispatch::Consumed
+        );
+        assert_eq!(
+            dispatch_global_key(key(KeyCode::Left), &mut state),
+            KeyDispatch::Consumed
+        );
+        let out = dispatch_global_key(key(KeyCode::Enter), &mut state);
+        assert_eq!(
+            out,
+            KeyDispatch::ToolApprovalDecision {
+                tool_id: "call-1".to_string(),
+                approved: false
+            }
+        );
     }
 
     #[test]
@@ -10826,7 +11079,10 @@ mod tests {
             80,
         );
         assert!(line.contains('\u{25B8}'), "active marker visible: {line}");
-        assert!(line.contains('⏳'), "status glyph visible: {line}");
+        assert!(
+            UNICODE_SPINNER_FRAMES.iter().any(|frame| line.contains(frame)),
+            "running status spinner visible: {line}"
+        );
         assert!(line.contains("#1"), "seq visible: {line}");
         assert!(line.contains("agent"), "kind visible: {line}");
         assert!(line.contains("task 1"), "title visible: {line}");
@@ -10941,6 +11197,143 @@ mod tests {
         assert!(
             line.contains('>') && line.contains('+'),
             "ASCII right overflow/count affordance appears when entries remain hidden: {line}"
+        );
+    }
+
+    #[test]
+    fn running_status_glyph_animates_with_shared_spinner_frames() {
+        let running = elapsed_entry(1, "running", 0);
+        assert_eq!(session_status_glyph_for_tick(&running, false, 0), "⠋");
+        assert_eq!(session_status_glyph_for_tick(&running, false, 1), "⠙");
+        assert_eq!(session_status_glyph_for_tick(&running, true, 0), "-");
+        assert_eq!(session_status_glyph_for_tick(&running, true, 1), "\\");
+
+        let completed = elapsed_entry(2, "completed", 0);
+        assert_eq!(
+            session_status_glyph_for_tick(&completed, false, 0),
+            session_status_glyph_for_tick(&completed, false, 1),
+            "non-running rows must stay static"
+        );
+    }
+
+    #[test]
+    fn periodic_redraw_tracks_running_bottom_entries_only() {
+        let mut state = TuiState::new("p", "m");
+        assert!(
+            !periodic_redraw_active_for_view(&state),
+            "idle chat has no animation tick"
+        );
+
+        state.sessions_cache = vec![elapsed_entry(1, "completed", 0)];
+        assert!(
+            !periodic_redraw_active_for_view(&state),
+            "completed bottom entries do not drive periodic redraw"
+        );
+
+        state.sessions_cache = vec![elapsed_entry(1, "running", 0)];
+        assert!(
+            periodic_redraw_active_for_view(&state),
+            "running bottom sessions drive the spinner redraw"
+        );
+
+        state.sessions_cache.clear();
+        state.provider_worker_status = ProviderWorkerStatus {
+            running: 1,
+            cancelling: 0,
+            awaiting_commit: 0,
+            finalized_payloads: 0,
+            finalized_total_tokens: 0,
+            oldest_started_at_ms: Some(0),
+            rows: vec![ProviderWorkerStatusRow {
+                task_id: 9,
+                sequence: 9,
+                kind: crate::chat::action::ProviderWorkerRowKind::Detached,
+                state: ProviderWorkerRowState::Running,
+                started_at_ms: 0,
+                finalized_total_tokens: None,
+                completion_ready: false,
+                recent_tool_call: None,
+            }],
+        };
+        assert!(
+            periodic_redraw_active_for_view(&state),
+            "running provider workers also drive the bottom spinner redraw"
+        );
+
+        let row = state
+            .provider_worker_status
+            .rows
+            .first_mut()
+            .expect("test status has one row");
+        row.state = ProviderWorkerRowState::Committed;
+        state.provider_worker_status.running = 0;
+        assert!(
+            !periodic_redraw_active_for_view(&state),
+            "terminal worker rows do not keep the periodic redraw alive"
+        );
+    }
+
+    #[test]
+    fn session_list_footer_includes_navigation_hint_when_entries_exist() {
+        let mut state = TuiState::new("p", "m");
+        state.sessions_cache = vec![elapsed_entry(1, "running", 0)];
+
+        let lines = render_sessions_list_lines(&state, 100, 4);
+        let rows = lines.iter().map(line_to_plain).collect::<Vec<_>>();
+
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("↑↓ sessions") && row.contains("Enter attach/open")),
+            "session footer should expose arrow navigation and Enter behavior: {rows:?}"
+        );
+        assert!(
+            footer_text(false, true).contains("↑↓ sessions"),
+            "static footer text helper also includes the dynamic hint"
+        );
+    }
+
+    #[test]
+    fn provider_worker_switcher_title_appends_latest_tool_summary_for_running_rows() {
+        let conversation = vec![ConversationLine::ToolResult {
+            tool_name: "shell".to_string(),
+            args_preview: "ls -la /tmp/demo".to_string(),
+            args_full: "{\"command\":\"ls -la /tmp/demo\"}".to_string(),
+            result: None,
+            status: ToolStatus::Running,
+            elapsed_ms: None,
+            folded: true,
+        }];
+        let summary =
+            latest_provider_worker_tool_summary_from_conversation(&conversation, false).expect("tool summary");
+        assert!(
+            summary.contains("run shell running: ls -la /tmp/demo"),
+            "summary uses the compact provider worker IO wording: {summary}"
+        );
+
+        let running = ProviderWorkerStatusRow {
+            task_id: 3,
+            sequence: 3,
+            kind: crate::chat::action::ProviderWorkerRowKind::Detached,
+            state: ProviderWorkerRowState::Running,
+            started_at_ms: 0,
+            finalized_total_tokens: None,
+            completion_ready: false,
+            recent_tool_call: Some(summary.clone()),
+        };
+        let entry = provider_worker_switcher_entry(&running);
+        assert!(
+            entry.title.contains(&summary),
+            "running worker title should include latest tool summary: {}",
+            entry.title
+        );
+
+        let mut completed = running;
+        completed.state = ProviderWorkerRowState::Committed;
+        let entry = provider_worker_switcher_entry(&completed);
+        assert!(
+            !entry.title.contains(&summary),
+            "terminal worker titles stay unchanged: {}",
+            entry.title
         );
     }
 
@@ -11258,6 +11651,7 @@ mod tests {
                 started_at_ms: chrono::Utc::now().timestamp_millis().saturating_sub(2_000),
                 finalized_total_tokens: None,
                 completion_ready: false,
+                recent_tool_call: None,
             }],
         }
     }
@@ -11753,7 +12147,7 @@ mod tests {
 
         let rows = fullscreen_rows(&state, 100, 24, &mut scroll);
         let joined = rows.join("\n");
-        let bottom = rows.last().cloned().unwrap_or_default();
+        let bottom = rows.iter().find(|row| row.contains("#1")).cloned().unwrap_or_default();
 
         assert!(
             joined.contains("main chat"),
@@ -11773,6 +12167,11 @@ mod tests {
             "bottom list should show the running task title, not shortcut-only chrome: {rows:?}"
         );
         assert!(
+            rows.iter()
+                .any(|row| row.contains("↑↓ sessions") && row.contains("Enter attach/open")),
+            "session list footer should expose navigation hint: {rows:?}"
+        );
+        assert!(
             !bottom.contains("Ctrl+G sessions"),
             "session list should replace shortcut footer while sessions exist: {rows:?}"
         );
@@ -11782,8 +12181,8 @@ mod tests {
             "session should render once below input, never duplicated above it: {rows:?}"
         );
         assert!(
-            !joined.contains('⏳') && !joined.contains('✓'),
-            "session list should use text status rather than status icons: {rows:?}"
+            UNICODE_SPINNER_FRAMES.iter().any(|frame| joined.contains(frame)) && !joined.contains('✓'),
+            "running session list rows should use animated spinner without terminal success icon: {rows:?}"
         );
     }
 
@@ -12347,6 +12746,7 @@ mod tests {
             tool_id: "tool-1".to_string(),
             name: "danger_tool".to_string(),
             args: "{\"path\":\"/tmp/demo\"}".to_string(),
+            selected_approval: false,
         });
         let mut scroll = FullscreenTranscriptScroll::default();
         scroll.jump_top();
@@ -12355,6 +12755,11 @@ mod tests {
         assert!(
             rows.iter().any(|row| row.contains("Tool Approval")),
             "approval panel visible outside transcript scroll: {rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("selected: deny") && row.contains("Enter confirm")),
+            "approval panel exposes arrow selection state and Enter confirmation: {rows:?}"
         );
         assert!(
             rows.iter().any(|row| row.contains("danger_tool")),
@@ -12473,16 +12878,16 @@ mod tests {
         let with_one = fullscreen_bottom_chrome_height(&state);
         assert_eq!(
             with_one,
-            idle.saturating_add(1),
-            "one child session adds one row because the list also includes main"
+            idle.saturating_add(2),
+            "one child session adds one row plus the session navigation hint"
         );
 
         state.sessions_cache = vec![entry(1), entry(2), entry(3)];
         let with_three = fullscreen_bottom_chrome_height(&state);
         assert_eq!(
             with_three,
-            idle.saturating_add(3),
-            "session list adds one row per child while retaining main"
+            idle.saturating_add(4),
+            "session list adds one row per child plus the navigation hint"
         );
 
         state.sessions_cache.clear();
@@ -12597,6 +13002,7 @@ mod tests {
                     started_at_ms: chrono::Utc::now().timestamp_millis().saturating_sub(3_000),
                     finalized_total_tokens: None,
                     completion_ready: false,
+                    recent_tool_call: None,
                 },
                 ProviderWorkerStatusRow {
                     task_id: 88,
@@ -12606,6 +13012,7 @@ mod tests {
                     started_at_ms: chrono::Utc::now().timestamp_millis().saturating_sub(9_000),
                     finalized_total_tokens: Some(1_250),
                     completion_ready: true,
+                    recent_tool_call: None,
                 },
             ],
         };
@@ -12661,6 +13068,7 @@ mod tests {
                 started_at_ms: chrono::Utc::now().timestamp_millis().saturating_sub(3_000),
                 finalized_total_tokens: None,
                 completion_ready: true,
+                recent_tool_call: None,
             }],
         };
 
@@ -12710,6 +13118,7 @@ mod tests {
                 started_at_ms: chrono::Utc::now().timestamp_millis().saturating_sub(2_000),
                 finalized_total_tokens: None,
                 completion_ready: false,
+                recent_tool_call: None,
             }],
         };
         state.start_stream("draft-worker");
@@ -13213,6 +13622,7 @@ mod tests {
                 tool_id: "call-approval".to_string(),
                 name: "shell".to_string(),
                 args: r#"{"cmd":"rm -rf /tmp/nope"}"#.to_string(),
+                selected_approval: false,
             };
             state.ui.pending_tool_approval = Some(pending.clone());
             state.ui.focus = crate::chat::sessions::FocusTarget::Approval;


### PR DESCRIPTION
## Summary
Addresses the F-U2/F-U3 demo feedback with two coordinated pieces, and bumps to **v0.8.2**.

### 1. UX polish (approvals, spinner, worker title, footer)
- Tool approval popup gains Left/Up = deny, Right/Down = approve, Enter = confirm current selection (default deny); `y`/`n`/Esc preserved.
- Bottom session/worker rows animate the shared spinner glyph while running. The 150ms redraw tick is gated on execution activity or a running bottom entry only; idle uses a 1000ms poll with no redraw-on-timeout (verified 0.00% idle CPU, ~2.2% with two active workers on a debug build — no livelock).
- Running worker rows append a compact latest-tool-call summary to the title.

### 2. Axis-separated key model (zero-mode)
Resolves the two user decisions (instant switch + arrows scroll transcript) into a coherent, unambiguous routing model (design: `task/prx/design-chat-key-model-rearrange-2026-07-11.md`):
- **Up/Down** scroll the current main transcript or child/worker sub-view; **Left/Right** immediately switch along the bottom session list (no select+Enter). Landing on main detaches/closes the child.
- **Input history → Ctrl+P / Ctrl+N**; bare Up/Down no longer recall history.
- **PageUp/PageDown/Home/End** are focus-aware and work even with a draft in the input.
- **Alt+arrow** strip navigation removed; the now-inert `strip_selection` field, `StripSelectionChanged` action, stale-selection reaping, and selected-highlight branches are deleted — highlight is purely focus-driven.
- **Key-repeat debounce (100ms)** suppresses rapid Left/Right attach storms.
- Footer hints updated to match the new semantics.

## Validation
- fmt / clippy `-D warnings` / check (all-features + no-default) clean
- Full suite **5483 passed / 0 failed**
- `cargo audit` + `cargo deny check advisories` green (RUSTSEC-2026-0189 stays resolved)
- Real-machine PTY demos: spinner frames animate, approval arrow selection, Up/Down scroll transcript (incl. with draft), Left/Right instant attach, Ctrl+P/N history, rapid Left/Right with no attach storm, focus-driven highlight

## Notes
- No visible-turn (P4b/P4c) scheduling or ordered-commit logic changed.
- Every piece was independently audited, mutation-tested, and PTY-verified before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)