### PR TITLE
feat(chat): colored unified diff for file edits + new-file previews (v0.8.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,7 +4680,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openprx"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2004,7 +2004,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2209,7 +2209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4484,7 +4484,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4572,7 +4572,7 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4581,7 +4581,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -4746,6 +4746,7 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9",
  "shellexpand",
+ "similar",
  "skillratings",
  "strsim",
  "subtle",
@@ -6461,7 +6462,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6980,6 +6981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7025,7 +7032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7251,7 +7258,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9180,7 +9187,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ thiserror = "2.0"
 
 # String similarity for tool name suggestions
 strsim = "0.11"
+similar = "2.7"
 
 # UUID generation
 uuid = { version = "1.11", default-features = false, features = ["v4", "v7", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "openprx"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 authors = ["g1e2x87"]
 license = "MIT OR Apache-2.0"

--- a/src/chat/renderer.rs
+++ b/src/chat/renderer.rs
@@ -212,7 +212,7 @@ fn take_digits(s: &str) -> (usize, &str) {
 ///
 /// We intentionally do NOT trigger on the mere presence of `+`/`-` prefixes:
 /// regular markdown lists (`- item`, `+ item`) would falsely match.
-fn is_diff_block(buffer: &str, language: Option<&str>) -> bool {
+pub(crate) fn is_diff_block(buffer: &str, language: Option<&str>) -> bool {
     if let Some(lang) = language
         && is_diff_language(lang)
     {

--- a/src/chat/state.rs
+++ b/src/chat/state.rs
@@ -2041,8 +2041,10 @@ impl ChatState {
     ) -> Vec<Effect> {
         use crate::chat::tui::{
             ARGS_PREVIEW_ELLIPSIS, ARGS_PREVIEW_MAX_CHARS, ConversationLine, ToolStatus, build_tool_args_preview,
+            tool_result_defaults_expanded,
         };
         let args_preview = build_tool_args_preview(&name, &args, ARGS_PREVIEW_MAX_CHARS, ARGS_PREVIEW_ELLIPSIS);
+        let folded = !tool_result_defaults_expanded(&name);
         let tool_key = ToolTaskKey::from_task_id(task_id);
         let invocation_key = ToolInvocationKey::new(tool_call_id, &name);
         self.control
@@ -2056,7 +2058,7 @@ impl ChatState {
             result: None,
             status: ToolStatus::Running,
             elapsed_ms: None,
-            folded: true,
+            folded,
         });
         let idx = self.ui.conversation_lines.len().saturating_sub(1);
         self.control.tool_buffer_mut(tool_key).pending_tool_cards.push(idx);
@@ -5577,6 +5579,27 @@ mod tests {
                 assert_eq!(*status, ToolStatus::Running);
             } else {
                 panic!("最后一行应是 Running ToolResult");
+            }
+        }
+
+        #[test]
+        fn test_redux_file_tool_cards_default_expanded() {
+            use crate::chat::tui::ConversationLine;
+            for (tool_name, expected_folded) in [("file_edit", false), ("file_write", false), ("shell", true)] {
+                let mut state = s();
+                let _ = state.reduce(Action::ToolStarted {
+                    task_id: None,
+                    sequence: None,
+                    tool_call_id: None,
+                    name: tool_name.to_string(),
+                    args: r#"{"path":"demo.txt"}"#.to_string(),
+                });
+                match state.ui.conversation_lines.last() {
+                    Some(ConversationLine::ToolResult { folded, .. }) => {
+                        assert_eq!(*folded, expected_folded, "{tool_name} folded default mismatch");
+                    }
+                    other => panic!("expected ToolResult for {tool_name}, got {other:?}"),
+                }
             }
         }
 

--- a/src/chat/tui.rs
+++ b/src/chat/tui.rs
@@ -3351,7 +3351,7 @@ impl TuiState {
             result: None,
             status: ToolStatus::Running,
             elapsed_ms: None,
-            folded: true,
+            folded: !tool_result_defaults_expanded(tool_name),
         });
     }
 
@@ -3488,6 +3488,10 @@ impl TuiState {
             .map(|l| estimate_line_height(l) as usize)
             .sum()
     }
+}
+
+pub(crate) fn tool_result_defaults_expanded(tool_name: &str) -> bool {
+    matches!(tool_name, "file_edit" | "file_write")
 }
 
 // ── P3-4: TuiMirrorSink adapter ─────────────────────────────────────────────
@@ -6111,16 +6115,26 @@ fn render_tool_result<'a>(
     }
 
     if folded {
-        push_folded_tool_summary(lines, hook, status, elapsed_ms, result, ascii);
+        push_folded_tool_summary(lines, hook, tool_name, status, elapsed_ms, result, ascii);
         return;
     }
 
-    push_expanded_tool_io(lines, hook, status, &display_preview, args_full, result, ascii);
+    push_expanded_tool_io(
+        lines,
+        hook,
+        tool_name,
+        status,
+        &display_preview,
+        args_full,
+        result,
+        ascii,
+    );
 }
 
 fn push_folded_tool_summary<'a>(
     lines: &mut Vec<Line<'a>>,
     hook: &str,
+    tool_name: &str,
     status: ToolStatus,
     elapsed_ms: Option<u64>,
     result: Option<&str>,
@@ -6150,10 +6164,10 @@ fn push_folded_tool_summary<'a>(
         Span::styled(status_glyph, Style::default().fg(status_color)),
         Span::styled(format!(" {metrics}"), metrics_style),
     ]));
-    push_folded_tool_result_preview(lines, result_text, ascii);
+    push_folded_tool_result_preview(lines, tool_name, result_text, ascii);
 }
 
-fn push_folded_tool_result_preview<'a>(lines: &mut Vec<Line<'a>>, result_text: &str, ascii: bool) {
+fn push_folded_tool_result_preview<'a>(lines: &mut Vec<Line<'a>>, tool_name: &str, result_text: &str, ascii: bool) {
     if result_text.trim().is_empty() {
         return;
     }
@@ -6164,6 +6178,24 @@ fn push_folded_tool_result_preview<'a>(lines: &mut Vec<Line<'a>>, result_text: &
     };
     let body_style = Style::default().fg(Color::DarkGray);
     let pipe = if ascii { "|" } else { "\u{2502}" };
+    if let Some(rendered) = tool_result_rendered_diff_body_lines(tool_name, result_text, body_style) {
+        let total_lines = rendered.len();
+        for body in rendered.iter().take(TOOL_FOLDED_RESULT_PREVIEW_LINES) {
+            push_prefixed_tool_body_line(lines, format!("    {pipe} "), body.clone(), body_style);
+        }
+        let hidden_lines = total_lines.saturating_sub(TOOL_FOLDED_RESULT_PREVIEW_LINES);
+        if hidden_lines > 0 {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "    {pipe} {ellipsis} +{hidden_lines} {}",
+                    if hidden_lines == 1 { "line" } else { "lines" }
+                ),
+                body_style,
+            )));
+        }
+        return;
+    }
+
     let result_lines = result_text.lines().collect::<Vec<_>>();
     let total_lines = result_lines.len();
     for body in result_lines.iter().take(TOOL_FOLDED_RESULT_PREVIEW_LINES) {
@@ -6185,6 +6217,7 @@ fn push_folded_tool_result_preview<'a>(lines: &mut Vec<Line<'a>>, result_text: &
 fn push_expanded_tool_io<'a>(
     lines: &mut Vec<Line<'a>>,
     hook: &str,
+    tool_name: &str,
     status: ToolStatus,
     display_preview: &str,
     args_full: &str,
@@ -6236,6 +6269,31 @@ fn push_expanded_tool_io<'a>(
         return;
     }
 
+    if let Some(rendered) = tool_result_rendered_diff_body_lines(tool_name, result_text, body_style) {
+        let total_lines = rendered.len();
+        let mut shown_lines = 0usize;
+        for body in rendered.iter().take(TOOL_EXPANDED_OUTPUT_MAX_LINES) {
+            push_prefixed_tool_body_line(lines, "    ".to_string(), body.clone(), body_style);
+            shown_lines = shown_lines.saturating_add(1);
+        }
+        let hidden_lines = total_lines.saturating_sub(shown_lines);
+        if hidden_lines > 0 {
+            let ellipsis = if ascii {
+                ARGS_PREVIEW_ELLIPSIS_ASCII
+            } else {
+                ARGS_PREVIEW_ELLIPSIS
+            };
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "    {ellipsis} truncated: {hidden_lines} {} hidden · Ctrl+O for full transcript",
+                    if hidden_lines == 1 { "line" } else { "lines" }
+                ),
+                body_style,
+            )));
+        }
+        return;
+    }
+
     let ellipsis = if ascii {
         ARGS_PREVIEW_ELLIPSIS_ASCII
     } else {
@@ -6270,6 +6328,57 @@ fn push_expanded_tool_io<'a>(
             body_style,
         )));
     }
+}
+
+fn tool_result_rendered_diff_body_lines(
+    tool_name: &str,
+    result_text: &str,
+    prefix_style: Style,
+) -> Option<Vec<Line<'static>>> {
+    if !matches!(tool_name, "file_edit" | "file_write") {
+        return None;
+    }
+    let diff_start = find_tool_result_diff_start(result_text)?;
+    let (prefix, diff) = result_text.split_at(diff_start);
+    if !crate::chat::renderer::is_diff_block(diff, None) {
+        return None;
+    }
+
+    let mut lines = prefix
+        .trim_end_matches('\n')
+        .lines()
+        .map(|line| Line::from(Span::styled(line.to_string(), prefix_style)))
+        .collect::<Vec<_>>();
+    lines.extend(ansi_sgr_to_lines(&crate::chat::renderer::render_diff_block(diff)));
+    Some(lines)
+}
+
+fn find_tool_result_diff_start(result_text: &str) -> Option<usize> {
+    let mut offset = 0usize;
+    for line in result_text.split_inclusive('\n') {
+        let content = line.trim_end_matches(['\n', '\r']);
+        if content.starts_with("diff --git ") || content.starts_with("--- a/") || content.starts_with("--- /") {
+            return Some(offset);
+        }
+        offset = offset.saturating_add(line.len());
+    }
+    let trailing = &result_text[offset..];
+    if trailing.starts_with("diff --git ") || trailing.starts_with("--- a/") || trailing.starts_with("--- /") {
+        return Some(offset);
+    }
+    None
+}
+
+fn push_prefixed_tool_body_line<'a>(
+    lines: &mut Vec<Line<'a>>,
+    prefix: String,
+    body: Line<'static>,
+    prefix_style: Style,
+) {
+    let mut spans = Vec::with_capacity(body.spans.len().saturating_add(1));
+    spans.push(Span::styled(prefix, prefix_style));
+    spans.extend(body.spans);
+    lines.push(Line::from(spans));
 }
 
 fn tool_card_metrics(status: ToolStatus, elapsed_ms: Option<u64>, result_text: &str, ascii: bool) -> String {
@@ -7837,6 +7946,21 @@ mod tests {
     }
 
     #[test]
+    fn file_edit_and_write_cards_default_expanded() {
+        for tool_name in ["file_edit", "file_write"] {
+            let mut state = TuiState::new("p", "m");
+            state.push_tool_result_started(tool_name, r#"{"path":"src/lib.rs"}"#);
+            let idx = state.last_tool_result_index().expect("test: tool result exists");
+            match state.conversation_lines.get(idx).expect("test: idx valid") {
+                ConversationLine::ToolResult { folded, .. } => {
+                    assert!(!*folded, "{tool_name} should default to expanded");
+                }
+                other => panic!("test: expected ToolResult, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn args_preview_truncates_long_input_and_collapses_newlines() {
         let raw = "x".repeat(150);
         let prev = build_args_preview(&raw, ARGS_PREVIEW_MAX_CHARS, ARGS_PREVIEW_ELLIPSIS);
@@ -8087,6 +8211,59 @@ mod tests {
         assert!(join(2).contains("2 lines"), "output metrics: {}", join(2));
         assert!(join(3).contains("total 24"), "first body row: {}", join(3));
         assert!(join(4).contains("drwxrwxrwt"), "second body row: {}", join(4));
+    }
+
+    #[test]
+    fn render_file_edit_diff_card_uses_colored_spans() {
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        let diff = "Applied 1 replacement in src/lib.rs\n\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1,2 +1,2 @@\n-old\n+new\n context\n";
+        let card = ConversationLine::ToolResult {
+            tool_name: "file_edit".to_string(),
+            args_preview: "path=src/lib.rs".to_string(),
+            args_full: r#"{"path":"src/lib.rs"}"#.to_string(),
+            result: Some(diff.to_string()),
+            status: ToolStatus::Done,
+            elapsed_ms: Some(42),
+            folded: false,
+        };
+
+        render_conversation_line(&mut lines, &card, false);
+
+        let rendered = lines.iter().map(line_to_plain).collect::<Vec<_>>().join("\n");
+        assert!(rendered.contains("@@ -1,2 +1,2 @@"), "hunk visible: {rendered}");
+        assert!(rendered.contains("-old"), "deletion visible: {rendered}");
+        assert!(rendered.contains("+new"), "addition visible: {rendered}");
+        assert_eq!(span_fg_for_content(&lines, "-old"), Some(Color::Red));
+        assert_eq!(span_fg_for_content(&lines, "+new"), Some(Color::Green));
+        assert_eq!(span_fg_for_content(&lines, "@@ -1,2 +1,2 @@"), Some(Color::Cyan));
+    }
+
+    #[test]
+    fn render_folded_file_write_diff_preview_keeps_color() {
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        let diff = "Written 5 bytes to new.txt\n\n--- /dev/null\n+++ b/new.txt\n@@ new file preview: first 40 lines @@\n   1 | hello\n";
+        let card = ConversationLine::ToolResult {
+            tool_name: "file_write".to_string(),
+            args_preview: "path=new.txt, bytes=5B".to_string(),
+            args_full: r#"{"path":"new.txt","content":"hello"}"#.to_string(),
+            result: Some(diff.to_string()),
+            status: ToolStatus::Done,
+            elapsed_ms: Some(10),
+            folded: true,
+        };
+
+        render_conversation_line(&mut lines, &card, false);
+
+        assert_eq!(
+            span_fg_for_content(&lines, "--- /dev/null"),
+            Some(Color::Gray),
+            "file header should be highlighted"
+        );
+        assert_eq!(
+            span_fg_for_content(&lines, "+++ b/new.txt"),
+            Some(Color::Gray),
+            "new file header should be highlighted"
+        );
     }
 
     #[test]

--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -2,6 +2,7 @@ use super::traits::{Tool, ToolCategory, ToolResult, ToolTier};
 use crate::security::op_id;
 use crate::security::policy::{ApprovalGrant, ResourceRiskLevel};
 use crate::security::{SecurityPolicy, SideEffectGate};
+use crate::tools::tool_diff::build_unified_diff;
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
@@ -25,29 +26,6 @@ impl FileEditTool {
     pub const fn new(security: Arc<SecurityPolicy>) -> Self {
         Self { security }
     }
-}
-
-/// Build a minimal unified-diff-style preview of the change. This is
-/// self-contained (the chat renderer's `render_diff_block` lives in the binary
-/// crate and is not reachable here) and intentionally compact: it shows the
-/// removed text as `-` lines and the inserted text as `+` lines under a single
-/// hunk header naming the file.
-fn build_unified_diff(path: &str, old_string: &str, new_string: &str) -> String {
-    let mut out = String::with_capacity(old_string.len() + new_string.len() + 64);
-    out.push_str(&format!("--- a/{path}\n"));
-    out.push_str(&format!("+++ b/{path}\n"));
-    out.push_str("@@ edit @@\n");
-    for line in old_string.split('\n') {
-        out.push('-');
-        out.push_str(line);
-        out.push('\n');
-    }
-    for line in new_string.split('\n') {
-        out.push('+');
-        out.push_str(line);
-        out.push('\n');
-    }
-    out
 }
 
 #[async_trait]
@@ -285,6 +263,7 @@ impl Tool for FileEditTool {
             // Exactly one occurrence: replacen with count 1 is sufficient.
             (contents.replacen(old_string, new_string, 1), 1)
         };
+        let diff = build_unified_diff(path, &contents, &new_contents);
 
         // Write the result back. O_NOFOLLOW again guards against a symlink being
         // swapped in between read and write.
@@ -317,7 +296,6 @@ impl Tool for FileEditTool {
                 if !self.security.record_action() {
                     tracing::warn!("file_edit succeeded for {path} but action budget was already exhausted");
                 }
-                let diff = build_unified_diff(path, old_string, new_string);
                 let suffix = if replacements == 1 { "" } else { "s" };
                 Ok(ToolResult {
                     success: true,
@@ -439,6 +417,11 @@ mod tests {
             .unwrap();
         assert!(result.success, "error: {:?}", result.error);
         assert!(result.output.contains("Applied 1 replacement"));
+        assert!(result.output.contains("--- a/f.txt"));
+        assert!(result.output.contains("+++ b/f.txt"));
+        assert!(result.output.contains("@@ -"));
+        assert!(result.output.contains("-hello world"));
+        assert!(result.output.contains("+hello rust"));
 
         let content = tokio::fs::read_to_string(dir.join("f.txt")).await.unwrap();
         assert_eq!(content, "hello rust\n");
@@ -507,6 +490,10 @@ mod tests {
             .unwrap();
         assert!(result.success, "error: {:?}", result.error);
         assert!(result.output.contains("Applied 4 replacements"));
+        assert!(result.output.contains("--- a/f.txt"));
+        assert!(result.output.contains("+++ b/f.txt"));
+        assert!(result.output.contains("-x x x x"));
+        assert!(result.output.contains("+y y y y"));
 
         let content = tokio::fs::read_to_string(dir.join("f.txt")).await.unwrap();
         assert_eq!(content, "y y y y");
@@ -642,10 +629,13 @@ mod tests {
 
     #[test]
     fn build_unified_diff_shows_minus_and_plus() {
-        let diff = build_unified_diff("f.txt", "old", "new");
+        let diff = build_unified_diff("f.txt", "one\nold\nthree\n", "one\nnew\nthree\n");
         assert!(diff.contains("--- a/f.txt"));
         assert!(diff.contains("+++ b/f.txt"));
+        assert!(diff.contains("@@ -"));
+        assert!(diff.contains(" one"));
         assert!(diff.contains("-old"));
         assert!(diff.contains("+new"));
+        assert!(diff.contains(" three"));
     }
 }

--- a/src/tools/file_write.rs
+++ b/src/tools/file_write.rs
@@ -2,6 +2,7 @@ use super::traits::{Tool, ToolCategory, ToolResult, ToolTier};
 use crate::security::op_id;
 use crate::security::policy::{ApprovalGrant, ResourceRiskLevel};
 use crate::security::{SecurityPolicy, SideEffectGate};
+use crate::tools::tool_diff::{build_new_file_preview, build_unified_diff};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
@@ -151,6 +152,17 @@ impl Tool for FileWriteTool {
             });
         }
 
+        let existing_contents = match read_existing_file_for_diff(&resolved_target).await {
+            Ok(contents) => contents,
+            Err(error) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(error.to_string()),
+                });
+            }
+        };
+
         // Use O_NOFOLLOW on Unix to atomically reject symlinks during open,
         // eliminating the TOCTOU race between symlink check and write.
         let target = resolved_target.clone();
@@ -176,11 +188,20 @@ impl Tool for FileWriteTool {
         .await;
 
         match write_result {
-            Ok(Ok(())) => Ok(ToolResult {
-                success: true,
-                output: format!("Written {} bytes to {path}", content.len()),
-                error: None,
-            }),
+            Ok(Ok(())) => {
+                let mut output = format!("Written {} bytes to {path}", content.len());
+                output.push_str("\n\n");
+                if let Some(old_contents) = existing_contents {
+                    output.push_str(&build_unified_diff(path, &old_contents, content));
+                } else {
+                    output.push_str(&build_new_file_preview(path, content));
+                }
+                Ok(ToolResult {
+                    success: true,
+                    output,
+                    error: None,
+                })
+            }
             Ok(Err(e)) => Ok(ToolResult {
                 success: false,
                 output: String::new(),
@@ -200,6 +221,39 @@ impl Tool for FileWriteTool {
 
     fn categories(&self) -> &'static [ToolCategory] {
         &[ToolCategory::FileSystem]
+    }
+}
+
+async fn read_existing_file_for_diff(path: &std::path::Path) -> anyhow::Result<Option<String>> {
+    if !tokio::fs::try_exists(path).await? {
+        return Ok(None);
+    }
+
+    let target = path.to_path_buf();
+    let read_result = tokio::task::spawn_blocking(move || -> Result<String, String> {
+        let mut opts = std::fs::OpenOptions::new();
+        opts.read(true);
+        #[cfg(unix)]
+        opts.custom_flags(libc::O_NOFOLLOW);
+
+        let mut file = opts.open(&target).map_err(|e| {
+            #[cfg(unix)]
+            if e.raw_os_error() == Some(libc::ELOOP) {
+                return format!("Refusing to overwrite symlink: {}", target.display());
+            }
+            format!("Failed to read existing file for diff: {e}")
+        })?;
+        let mut contents = String::new();
+        std::io::Read::read_to_string(&mut file, &mut contents)
+            .map_err(|e| format!("Failed to read existing file for diff: {e}"))?;
+        Ok(contents)
+    })
+    .await;
+
+    match read_result {
+        Ok(Ok(contents)) => Ok(Some(contents)),
+        Ok(Err(error)) => anyhow::bail!(error),
+        Err(error) => anyhow::bail!("Failed to read existing file for diff: {error}"),
     }
 }
 
@@ -275,6 +329,9 @@ mod tests {
         let result = tool.execute(approved_args(&dir, "out.txt", "written!")).await.unwrap();
         assert!(result.success);
         assert!(result.output.contains("8 bytes"));
+        assert!(result.output.contains("--- /dev/null"));
+        assert!(result.output.contains("+++ b/out.txt"));
+        assert!(result.output.contains("   1 | written!"));
 
         let content = tokio::fs::read_to_string(dir.join("out.txt")).await.unwrap();
         assert_eq!(content, "written!");
@@ -311,6 +368,12 @@ mod tests {
         let tool = FileWriteTool::new(test_security(dir.clone()));
         let result = tool.execute(approved_args(&dir, "exist.txt", "new")).await.unwrap();
         assert!(result.success);
+        assert!(result.output.contains("Written 3 bytes to exist.txt"));
+        assert!(result.output.contains("--- a/exist.txt"));
+        assert!(result.output.contains("+++ b/exist.txt"));
+        assert!(result.output.contains("@@ -"));
+        assert!(result.output.contains("-old"));
+        assert!(result.output.contains("+new"));
 
         let content = tokio::fs::read_to_string(dir.join("exist.txt")).await.unwrap();
         assert_eq!(content, "new");
@@ -390,6 +453,26 @@ mod tests {
         let result = tool.execute(approved_args(&dir, "empty.txt", "")).await.unwrap();
         assert!(result.success);
         assert!(result.output.contains("0 bytes"));
+        assert!(result.output.contains("--- /dev/null"));
+        assert!(result.output.contains("+++ b/empty.txt"));
+        assert!(result.output.contains("   1 | "));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_write_new_file_preview_is_bounded() {
+        let dir = std::env::temp_dir().join("openprx_test_file_write_preview_bound");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let content = (1..=45).map(|n| format!("line {n}")).collect::<Vec<_>>().join("\n");
+        let tool = FileWriteTool::new(test_security(dir.clone()));
+        let result = tool.execute(approved_args(&dir, "long.txt", &content)).await.unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("  40 | line 40"));
+        assert!(result.output.contains("... +5 more lines"));
+        assert!(!result.output.contains("line 41\n"));
 
         let _ = tokio::fs::remove_dir_all(&dir).await;
     }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -54,6 +54,7 @@ pub mod sessions_spawn;
 pub mod shell;
 pub mod stay_silent;
 pub mod subagents;
+pub(crate) mod tool_diff;
 pub mod traits;
 pub mod web_fetch;
 pub mod web_search_tool;

--- a/src/tools/tool_diff.rs
+++ b/src/tools/tool_diff.rs
@@ -1,0 +1,100 @@
+use similar::{Algorithm, TextDiff};
+
+const DIFF_CONTEXT_RADIUS: usize = 3;
+const DIFF_MAX_LINES: usize = 240;
+const PREVIEW_MAX_LINES: usize = 40;
+const PREVIEW_LINE_MAX_CHARS: usize = 220;
+
+pub(crate) fn build_unified_diff(path: &str, old: &str, new: &str) -> String {
+    let diff = TextDiff::configure().algorithm(Algorithm::Myers).diff_lines(old, new);
+    let rendered = diff
+        .unified_diff()
+        .context_radius(DIFF_CONTEXT_RADIUS)
+        .missing_newline_hint(false)
+        .header(&format!("a/{path}"), &format!("b/{path}"))
+        .to_string();
+    cap_diff_lines(&rendered)
+}
+
+pub(crate) fn build_new_file_preview(path: &str, content: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("--- /dev/null\n+++ b/{path}\n"));
+    out.push_str(&format!("@@ new file preview: first {PREVIEW_MAX_LINES} lines @@\n"));
+
+    let mut shown = 0usize;
+    let mut truncated_line = false;
+    for (idx, line) in content.lines().take(PREVIEW_MAX_LINES).enumerate() {
+        shown = shown.saturating_add(1);
+        let rendered = truncate_chars(line, PREVIEW_LINE_MAX_CHARS);
+        truncated_line |= rendered.len() != line.len();
+        out.push_str(&format!("{:>4} | {rendered}\n", idx.saturating_add(1)));
+    }
+
+    if content.is_empty() {
+        out.push_str("   1 | \n");
+    }
+
+    let total_lines = content.lines().count();
+    if total_lines > shown {
+        out.push_str(&format!("... +{} more lines\n", total_lines.saturating_sub(shown)));
+    } else if truncated_line {
+        out.push_str("... one or more lines truncated\n");
+    }
+    out
+}
+
+fn truncate_chars(input: &str, max_chars: usize) -> String {
+    if input.chars().count() <= max_chars {
+        return input.to_string();
+    }
+    let mut out = input.chars().take(max_chars).collect::<String>();
+    out.push('…');
+    out
+}
+
+fn cap_diff_lines(diff: &str) -> String {
+    let mut out = String::new();
+    let mut truncated = false;
+    for (idx, line) in diff.lines().enumerate() {
+        if idx >= DIFF_MAX_LINES {
+            truncated = true;
+            break;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    if truncated {
+        out.push_str(&format!("... diff truncated after {DIFF_MAX_LINES} lines\n"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unified_diff_includes_headers_hunk_context_and_changes() {
+        let old = "one\ntwo\nthree\nfour\n";
+        let new = "one\ntwo changed\nthree\nfour\n";
+        let diff = build_unified_diff("f.txt", old, new);
+        assert!(diff.contains("--- a/f.txt"));
+        assert!(diff.contains("+++ b/f.txt"));
+        assert!(diff.contains("@@ -1,4 +1,4 @@"));
+        assert!(diff.contains(" one"));
+        assert!(diff.contains("-two"));
+        assert!(diff.contains("+two changed"));
+    }
+
+    #[test]
+    fn new_file_preview_has_line_numbers_and_caps_rows() {
+        let content = (1..=45).map(|n| format!("line {n}")).collect::<Vec<_>>().join("\n");
+        let preview = build_new_file_preview("new.txt", &content);
+        assert!(preview.contains("--- /dev/null"));
+        assert!(preview.contains("+++ b/new.txt"));
+        assert!(preview.contains("   1 | line 1"));
+        assert!(preview.contains("  40 | line 40"));
+        assert!(preview.contains("... +5 more lines"));
+        assert!(!preview.contains("line 41\n"));
+    }
+}


### PR DESCRIPTION
## Summary
Makes `prx chat` render file edits and new-file creation like Claude Code: colored unified diffs with line numbers + context, and line-numbered previews for new files. Bumps to **v0.8.4**.

Root cause of the gap: the diff colorizer (`render_diff_block`) already existed but was only used for assistant markdown ```diff``` blocks — tool cards rendered results as flat gray text, and `file_edit` emitted a degenerate no-context diff while `file_write` had no preview at all.

## Changes
### Tool layer
- New `src/tools/tool_diff.rs`: real unified diffs (`---`/`+++`/`@@` hunk ranges with context) via the `similar` crate, plus bounded line-numbered previews for new files.
- `file_edit` emits context + line-number unified diffs.
- `file_write` distinguishes new vs overwrite: new files get a numbered content preview, overwrites get a unified diff; symlink refusal preserved.

### TUI
- `file_edit`/`file_write` result cards default expanded (both mirror and Redux reducer paths); other tools stay folded.
- Folded and expanded diff bodies route through `render_diff_block` + `ansi_sgr_to_lines` for +green / -red / @@cyan coloring.

Adds `similar = 2.7` (passes cargo-deny bans/licenses/sources).

## Validation
- fmt / clippy `-D warnings` / check (all-features + no-default) clean
- Full suite **5493 passed / 0 failed** (rebased onto v0.8.3; file-edit + D5 tests coexist with no regression)
- `cargo audit` + `cargo deny check advisories` + bans/licenses/sources green
- Real-machine PTY demos with ANSI evidence (hunk `38;5;6m`, minus `38;5;1m`, plus `38;5;2m`) for edit, new-file preview, and overwrite diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)