### PR TITLE
feat(chat): history/copy discoverability + fix PTY-detach mouse regression (v0.8.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,7 +4680,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openprx"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "openprx"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2024"
 authors = ["g1e2x87"]
 license = "MIT OR Apache-2.0"

--- a/src/chat/action.rs
+++ b/src/chat/action.rs
@@ -275,6 +275,9 @@ pub enum Action {
     SlashCommandIssued { cmd: String, args: String },
     /// 模式切换（/plan /edit /auto）
     ModeChanged(ChatMode),
+    /// UI-only mouse-selection mode: true means mouse capture is temporarily
+    /// released so the terminal can do native drag selection.
+    MouseSelectionModeChanged { active: bool },
     /// 模型在线切换（/model <name>）— BUG-07.
     ///
     /// reducer 更新 `session.model`，让 status bar 立刻反映新 model；真正影响
@@ -598,6 +601,7 @@ impl Action {
             Self::InputCancelled => "InputCancelled",
             Self::SlashCommandIssued { .. } => "SlashCommandIssued",
             Self::ModeChanged(_) => "ModeChanged",
+            Self::MouseSelectionModeChanged { .. } => "MouseSelectionModeChanged",
             Self::ModelChanged { .. } => "ModelChanged",
             Self::ProviderChanged { .. } => "ProviderChanged",
             Self::HistoryCleared => "HistoryCleared",

--- a/src/chat/commands.rs
+++ b/src/chat/commands.rs
@@ -456,6 +456,9 @@ pub fn help_text() -> String {
         out.push('\n');
         out.push_str(&format!("  {:<24} {}", spec.usage(), spec.description));
     }
+    out.push_str(
+        "\n\nHistory view & copy:\n  Home/PageUp scroll the in-app transcript; Ctrl+O opens the transcript viewer.\n  prx chat --plain or PRX_TUI=0 restores native terminal scrollback and drag selection.\n  /copy latest|N copies assistant replies; /export md|json writes the full session.",
+    );
     out
 }
 
@@ -1167,6 +1170,14 @@ mod mode_tests {
         assert!(help.contains("/theme"), "drift regression: /theme must be in help");
         assert!(help.contains("/approve"), "drift regression: /approve must be in help");
         assert!(help.contains("/deny"), "drift regression: /deny must be in help");
+        assert!(
+            help.contains("History view & copy"),
+            "help must explain history viewing and copy options: {help}"
+        );
+        assert!(
+            help.contains("prx chat --plain") && help.contains("/copy latest|N") && help.contains("/export md|json"),
+            "help must mention plain mode, /copy, and /export: {help}"
+        );
     }
 
     #[tokio::test]

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -1611,6 +1611,48 @@ fn apply_fullscreen_mouse_scroll(
     }
 }
 
+#[cfg(feature = "terminal-tui")]
+fn toggle_mouse_selection_mode(
+    mirror: &Arc<parking_lot::Mutex<tui::TuiState>>,
+    chat_dispatcher: &dispatcher::ChatDispatcher,
+    redraw_tx: &mpsc::Sender<()>,
+) {
+    let configured = CHAT_MOUSE_CAPTURE_CONFIGURED.load(Ordering::Acquire);
+    let selection_active = CHAT_MOUSE_SELECTION_MODE_ACTIVE.load(Ordering::Acquire);
+    let mut ops = CrosstermTerminalModeOps;
+    let outcome = match toggle_mouse_selection_mode_with_ops(&mut ops, configured, selection_active) {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to toggle chat mouse selection mode");
+            return;
+        }
+    };
+
+    let active = match outcome {
+        MouseSelectionModeOutcome::NotConfigured => false,
+        MouseSelectionModeOutcome::SelectionEnabled => {
+            CHAT_MOUSE_CAPTURE_ACTIVE.store(false, Ordering::Release);
+            CHAT_MOUSE_SELECTION_MODE_ACTIVE.store(true, Ordering::Release);
+            true
+        }
+        MouseSelectionModeOutcome::MouseRestored => {
+            CHAT_MOUSE_CAPTURE_ACTIVE.store(true, Ordering::Release);
+            CHAT_MOUSE_SELECTION_MODE_ACTIVE.store(false, Ordering::Release);
+            false
+        }
+    };
+
+    {
+        let mut guard = mirror.lock();
+        guard.mouse_selection_mode_active = active;
+    }
+    let _ = chat_dispatcher.dispatch_or_log(
+        crate::chat::action::Action::MouseSelectionModeChanged { active },
+        "chat.mouse_selection_mode_changed",
+    );
+    let _ = redraw_tx.try_send(());
+}
+
 /// Surface a background-session system message into the chat (v1b reflow).
 ///
 /// Standalone (not the in-loop `emit_chat_output` closure) so the main loop's
@@ -2623,6 +2665,7 @@ fn log_redux_key_diff(old: &tui::KeyDispatch, new_effects: &[state::Effect]) {
         tui::KeyDispatch::ExternalEditorRequested => "ExternalEditorRequested",
         tui::KeyDispatch::ToolApprovalDecision { .. } => "ToolApprovalDecision",
         tui::KeyDispatch::ModeChanged(_) => "ModeChanged",
+        tui::KeyDispatch::ToggleMouseSelectionMode => "ToggleMouseSelectionMode",
     };
     let new_kinds: Vec<&'static str> = new_effects
         .iter()
@@ -2690,7 +2733,8 @@ fn log_redux_key_diff(old: &tui::KeyDispatch, new_effects: &[state::Effect]) {
         | tui::KeyDispatch::CloseDiffViewer
         | tui::KeyDispatch::ExternalEditorRequested
         | tui::KeyDispatch::ToolApprovalDecision { .. }
-        | tui::KeyDispatch::ModeChanged(_) => new_has_quit,
+        | tui::KeyDispatch::ModeChanged(_)
+        | tui::KeyDispatch::ToggleMouseSelectionMode => new_has_quit,
     };
 
     if is_diff {
@@ -2947,6 +2991,34 @@ impl TerminalModeOps for CrosstermTerminalModeOps {
 static CHAT_FULLSCREEN_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 static CHAT_KEYBOARD_ENHANCEMENT_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 static CHAT_MOUSE_CAPTURE_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static CHAT_MOUSE_CAPTURE_CONFIGURED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static CHAT_MOUSE_SELECTION_MODE_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(feature = "terminal-tui")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MouseSelectionModeOutcome {
+    NotConfigured,
+    SelectionEnabled,
+    MouseRestored,
+}
+
+#[cfg(feature = "terminal-tui")]
+fn toggle_mouse_selection_mode_with_ops(
+    ops: &mut impl TerminalModeOps,
+    mouse_capture_configured: bool,
+    selection_mode_active: bool,
+) -> std::io::Result<MouseSelectionModeOutcome> {
+    if !mouse_capture_configured {
+        return Ok(MouseSelectionModeOutcome::NotConfigured);
+    }
+    if selection_mode_active {
+        ops.enable_mouse_capture()?;
+        Ok(MouseSelectionModeOutcome::MouseRestored)
+    } else {
+        ops.disable_mouse_capture()?;
+        Ok(MouseSelectionModeOutcome::SelectionEnabled)
+    }
+}
 
 fn enter_terminal_state_with_ops(ops: &mut impl TerminalModeOps) -> std::io::Result<TerminalGuardState> {
     let mouse_enabled = mouse_capture_enabled_by_env(
@@ -2966,6 +3038,8 @@ fn enter_terminal_state_with_ops_inner(
     state.raw_mode_active = true;
 
     CHAT_FULLSCREEN_ACTIVE.store(true, std::sync::atomic::Ordering::Release);
+    CHAT_MOUSE_CAPTURE_CONFIGURED.store(false, std::sync::atomic::Ordering::Release);
+    CHAT_MOUSE_SELECTION_MODE_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
     if let Err(e) = ops.enter_alternate_screen() {
         CHAT_FULLSCREEN_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
         let _ = ops.disable_raw_mode();
@@ -2984,6 +3058,8 @@ fn enter_terminal_state_with_ops_inner(
         }
         state.mouse_capture_active = true;
         CHAT_MOUSE_CAPTURE_ACTIVE.store(true, std::sync::atomic::Ordering::Release);
+        CHAT_MOUSE_CAPTURE_CONFIGURED.store(true, std::sync::atomic::Ordering::Release);
+        CHAT_MOUSE_SELECTION_MODE_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
     }
 
     match ops.supports_keyboard_enhancement() {
@@ -2992,6 +3068,8 @@ fn enter_terminal_state_with_ops_inner(
                 if state.mouse_capture_active {
                     let _ = ops.disable_mouse_capture();
                     CHAT_MOUSE_CAPTURE_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
+                    CHAT_MOUSE_CAPTURE_CONFIGURED.store(false, std::sync::atomic::Ordering::Release);
+                    CHAT_MOUSE_SELECTION_MODE_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
                 }
                 if state.alternate_screen_active {
                     let _ = ops.leave_alternate_screen();
@@ -3017,6 +3095,8 @@ fn enter_terminal_state_with_ops_inner(
         if state.mouse_capture_active {
             let _ = ops.disable_mouse_capture();
             CHAT_MOUSE_CAPTURE_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
+            CHAT_MOUSE_CAPTURE_CONFIGURED.store(false, std::sync::atomic::Ordering::Release);
+            CHAT_MOUSE_SELECTION_MODE_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
         }
         if state.alternate_screen_active {
             let _ = ops.leave_alternate_screen();
@@ -3043,6 +3123,8 @@ fn leave_terminal_state_with_ops(ops: &mut impl TerminalModeOps, state: Terminal
         let _ = ops.disable_mouse_capture();
         CHAT_MOUSE_CAPTURE_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
     }
+    CHAT_MOUSE_CAPTURE_CONFIGURED.store(false, std::sync::atomic::Ordering::Release);
+    CHAT_MOUSE_SELECTION_MODE_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
     if state.alternate_screen_active {
         let _ = ops.leave_alternate_screen();
         CHAT_FULLSCREEN_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
@@ -10711,6 +10793,7 @@ fn write_external_editor_restore_sequences(out: &mut dyn std::io::Write) {
     crate::chat::sessions::pty::write_handoff_terminal_restore(
         out,
         CHAT_KEYBOARD_ENHANCEMENT_ACTIVE.load(std::sync::atomic::Ordering::Acquire),
+        CHAT_MOUSE_CAPTURE_ACTIVE.load(std::sync::atomic::Ordering::Acquire),
     );
 }
 
@@ -11509,6 +11592,7 @@ async fn reattach_pty(
             handoff,
             redraw_nudge,
             CHAT_KEYBOARD_ENHANCEMENT_ACTIVE.load(std::sync::atomic::Ordering::Acquire),
+            CHAT_MOUSE_CAPTURE_ACTIVE.load(std::sync::atomic::Ordering::Acquire),
         ) else {
             return PtyOutcome::AttachAborted;
         };
@@ -12281,6 +12365,9 @@ fn run_tui_unified_loop(
                             .dispatch_or_log(crate::chat::action::Action::ModeChanged(mode), "chat.mode_changed_key");
                         let _ = redraw_tx.try_send(());
                     }
+                    tui::KeyDispatch::ToggleMouseSelectionMode => {
+                        toggle_mouse_selection_mode(&mirror, chat_dispatcher, &redraw_tx);
+                    }
                     tui::KeyDispatch::RequestDetach => {
                         // Esc on empty input while a session is focused → route a
                         // synthetic `/detach` so the main loop clears
@@ -12400,6 +12487,9 @@ fn run_tui_unified_loop(
                 let _ = redraw_tx.try_send(());
             }
             Event::Mouse(mouse) => {
+                if CHAT_MOUSE_SELECTION_MODE_ACTIVE.load(Ordering::Acquire) {
+                    continue;
+                }
                 if apply_fullscreen_mouse_scroll(mouse.kind, &mut fullscreen_scroll) {
                     let _ = redraw_tx.try_send(());
                 } else if matches!(
@@ -14488,6 +14578,28 @@ mod terminal_guard_tests {
     }
 
     #[test]
+    fn ctrl_space_mouse_selection_toggle_releases_and_restores_mouse_capture() {
+        let mut ops = FakeTerminalModeOps::default();
+
+        let released = toggle_mouse_selection_mode_with_ops(&mut ops, true, false).unwrap();
+        let restored = toggle_mouse_selection_mode_with_ops(&mut ops, true, true).unwrap();
+
+        assert_eq!(released, MouseSelectionModeOutcome::SelectionEnabled);
+        assert_eq!(restored, MouseSelectionModeOutcome::MouseRestored);
+        assert_eq!(ops.calls, vec!["disable_mouse_capture", "enable_mouse_capture"]);
+    }
+
+    #[test]
+    fn ctrl_space_mouse_selection_toggle_is_noop_when_mouse_was_not_configured() {
+        let mut ops = FakeTerminalModeOps::default();
+
+        let outcome = toggle_mouse_selection_mode_with_ops(&mut ops, false, false).unwrap();
+
+        assert_eq!(outcome, MouseSelectionModeOutcome::NotConfigured);
+        assert!(ops.calls.is_empty());
+    }
+
+    #[test]
     fn fullscreen_enter_rolls_back_alternate_screen_when_mouse_capture_fails() {
         let mut ops = FakeTerminalModeOps {
             fail_enable_mouse_capture: true,
@@ -15554,6 +15666,7 @@ mod p6b2_external_editor_tests {
     #[test]
     fn external_editor_fullscreen_suspend_leaves_alt_and_restore_reenters() {
         CHAT_KEYBOARD_ENHANCEMENT_ACTIVE.store(false, Ordering::SeqCst);
+        let previous_mouse_capture = CHAT_MOUSE_CAPTURE_ACTIVE.swap(true, Ordering::SeqCst);
         let mut suspend = Vec::new();
         write_external_editor_suspend_sequences(&mut suspend);
         let suspend = String::from_utf8(suspend).expect("test: suspend escape bytes are utf-8");
@@ -15565,6 +15678,7 @@ mod p6b2_external_editor_tests {
         let mut restore = Vec::new();
         write_external_editor_restore_sequences(&mut restore);
         let restore = String::from_utf8(restore).expect("test: restore escape bytes are utf-8");
+        CHAT_MOUSE_CAPTURE_ACTIVE.store(previous_mouse_capture, Ordering::SeqCst);
         assert!(
             restore.contains("\x1b[?1049l") && restore.contains("\x1b[?47l"),
             "fullscreen editor restore must reset any child/editor alt-screen first: {restore:?}"

--- a/src/chat/sessions/pty.rs
+++ b/src/chat/sessions/pty.rs
@@ -209,6 +209,7 @@ impl HandoffControl {
 pub struct PtyHandoffGuard {
     control: Arc<HandoffControl>,
     keyboard_enhancement_active: bool,
+    mouse_capture_active: bool,
     /// Best-effort redraw nudge so the render loop repaints immediately on
     /// resume rather than waiting out its idle poll. `None` when the chat has no
     /// TUI render loop (fallback path); restoration still works via the flag.
@@ -233,6 +234,7 @@ impl PtyHandoffGuard {
         control: Arc<HandoffControl>,
         redraw_nudge: Option<Box<dyn Fn() + Send>>,
         keyboard_enhancement_active: bool,
+        mouse_capture_active: bool,
     ) -> Option<Self> {
         // Block (bounded) until the render loop confirms it has parked.
         if control.pause_and_wait(PAUSE_ACK_TIMEOUT) {
@@ -241,6 +243,7 @@ impl PtyHandoffGuard {
             return Some(Self {
                 control,
                 keyboard_enhancement_active,
+                mouse_capture_active,
                 redraw_nudge,
             });
         }
@@ -284,14 +287,17 @@ impl Drop for PtyHandoffGuard {
         //     Done while the render loop is still parked so we are the sole writer.
         {
             let mut out = std::io::stdout();
-            write_handoff_terminal_restore(&mut out, self.keyboard_enhancement_active);
+            write_handoff_terminal_restore(&mut out, self.keyboard_enhancement_active, self.mouse_capture_active);
         }
 
         // 1b. Defensively re-assert the chat terminal modes the PTY child may
         //     have clobbered, while the render loop is still parked so we are the
-        //     sole writer of these escape/kernel operations. Best-effort.
+        //     sole writer of these escape/kernel operations. Mouse capture is
+        //     restored only if chat owned it before the handoff. Best-effort.
         let _ = crossterm::terminal::enable_raw_mode();
-        let _ = crossterm::execute!(std::io::stdout(), crossterm::event::EnableMouseCapture);
+        if self.mouse_capture_active {
+            let _ = crossterm::execute!(std::io::stdout(), crossterm::event::EnableMouseCapture);
+        }
         let _ = crossterm::execute!(std::io::stdout(), crossterm::event::EnableBracketedPaste);
 
         // 2 & 3. Arm the full redraw (to wipe PTY residue) and only THEN unpause,
@@ -355,10 +361,16 @@ pub(crate) fn write_chat_alt_screen_leave_for_handoff(out: &mut dyn std::io::Wri
     }
 }
 
-pub(crate) fn write_handoff_terminal_restore(out: &mut dyn std::io::Write, keyboard_enhancement_active: bool) {
+pub(crate) fn write_handoff_terminal_restore(
+    out: &mut dyn std::io::Write,
+    keyboard_enhancement_active: bool,
+    mouse_capture_active: bool,
+) {
     let result = out.write_all(HOST_MODE_RESET).and_then(|()| {
         out.write_all(CHAT_ALT_SCREEN_ENTER)?;
-        out.write_all(CHAT_MOUSE_CAPTURE_ENABLE)?;
+        if mouse_capture_active {
+            out.write_all(CHAT_MOUSE_CAPTURE_ENABLE)?;
+        }
         if keyboard_enhancement_active {
             out.write_all(CHAT_KEYBOARD_ENHANCEMENT_PUSH)?;
         }
@@ -1439,6 +1451,7 @@ mod tests {
                 Arc::clone(&control),
                 Some(Box::new(move || nudged2.store(true, Ordering::Release))),
                 true,
+                true,
             )
             .expect("test: ack arrives so acquire succeeds");
             // During the handoff the render loop is paused.
@@ -1461,7 +1474,7 @@ mod tests {
         let acker = spawn_acking_render_loop(&control);
         let control2 = Arc::clone(&control);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = PtyHandoffGuard::acquire(Arc::clone(&control2), None, true)
+            let _guard = PtyHandoffGuard::acquire(Arc::clone(&control2), None, true, true)
                 .expect("test: ack arrives so acquire succeeds");
             assert!(control2.is_paused());
             panic!("test: simulate a fault during PTY handoff");
@@ -1483,7 +1496,7 @@ mod tests {
         let acker = spawn_acking_render_loop(&control);
         let control2 = Arc::clone(&control);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = PtyHandoffGuard::acquire(Arc::clone(&control2), None, true)
+            let _guard = PtyHandoffGuard::acquire(Arc::clone(&control2), None, true, true)
                 .expect("test: ack arrives so acquire succeeds");
             assert!(control2.is_paused());
             panic!("test: simulate a fullscreen PTY handoff fault");
@@ -1504,7 +1517,7 @@ mod tests {
         // untouched), never proceed with a half-done handoff.
         let control = Arc::new(HandoffControl::new());
         // No acker thread → the ack will time out.
-        let guard = PtyHandoffGuard::acquire(Arc::clone(&control), None, true);
+        let guard = PtyHandoffGuard::acquire(Arc::clone(&control), None, true, true);
         assert!(guard.is_none(), "acquire must refuse when the render loop never parks");
         assert!(
             !control.is_paused(),
@@ -1522,8 +1535,8 @@ mod tests {
         // `!is_paused()` always also sees `force_redraw == true`.
         let control = Arc::new(HandoffControl::new());
         let acker = spawn_acking_render_loop(&control);
-        let guard =
-            PtyHandoffGuard::acquire(Arc::clone(&control), None, true).expect("test: ack arrives so acquire succeeds");
+        let guard = PtyHandoffGuard::acquire(Arc::clone(&control), None, true, true)
+            .expect("test: ack arrives so acquire succeeds");
         assert!(control.is_paused());
         drop(guard);
         acker.join().expect("test: acker joins");
@@ -1544,7 +1557,7 @@ mod tests {
         // so a regression that drops one (re-introducing the residual-mode bug)
         // fails loudly.
         let mut captured: Vec<u8> = Vec::new();
-        write_handoff_terminal_restore(&mut captured, true);
+        write_handoff_terminal_restore(&mut captured, true, true);
         let s = String::from_utf8(captured).expect("test: reset is valid utf-8");
 
         // Mouse tracking off (X10 / button / any-motion / utf8 / sgr coords).
@@ -1582,8 +1595,8 @@ mod tests {
         // whether a child actually changed them, including the no-TUI path).
         let mut a: Vec<u8> = Vec::new();
         let mut b: Vec<u8> = Vec::new();
-        write_handoff_terminal_restore(&mut a, true);
-        write_handoff_terminal_restore(&mut b, true);
+        write_handoff_terminal_restore(&mut a, true, true);
+        write_handoff_terminal_restore(&mut b, true, true);
         assert_eq!(a, b, "host mode reset must be a deterministic constant");
         assert!(
             a.starts_with(HOST_MODE_RESET) && a.ends_with(CHAT_KEYBOARD_ENHANCEMENT_PUSH),
@@ -1594,7 +1607,7 @@ mod tests {
     #[test]
     fn fullscreen_handoff_restore_resets_child_then_reenters_chat_alt_screen_and_mouse() {
         let mut captured: Vec<u8> = Vec::new();
-        write_handoff_terminal_restore(&mut captured, true);
+        write_handoff_terminal_restore(&mut captured, true, true);
         assert!(
             captured.starts_with(HOST_MODE_RESET),
             "fullscreen restore must first reset child terminal modes: {captured:?}"
@@ -1614,6 +1627,29 @@ mod tests {
         assert!(
             captured.ends_with(CHAT_KEYBOARD_ENHANCEMENT_PUSH),
             "fullscreen restore must re-push keyboard enhancement flags after handoff: {captured:?}"
+        );
+    }
+
+    #[test]
+    fn fullscreen_handoff_restore_does_not_enable_mouse_when_chat_mouse_was_off() {
+        let mut captured: Vec<u8> = Vec::new();
+        write_handoff_terminal_restore(&mut captured, true, false);
+
+        assert!(
+            captured.starts_with(HOST_MODE_RESET),
+            "fullscreen restore must still reset child terminal modes: {captured:?}"
+        );
+        assert!(
+            captured
+                .windows(CHAT_ALT_SCREEN_ENTER.len())
+                .any(|window| window == CHAT_ALT_SCREEN_ENTER),
+            "fullscreen restore must still re-enter chat alt-screen: {captured:?}"
+        );
+        assert!(
+            !captured
+                .windows(CHAT_MOUSE_CAPTURE_ENABLE.len())
+                .any(|window| window == CHAT_MOUSE_CAPTURE_ENABLE),
+            "mouse-off chat sessions must not re-enable mouse capture after PTY detach: {captured:?}"
         );
     }
 
@@ -1655,7 +1691,7 @@ mod tests {
         );
 
         let mut restore = Vec::new();
-        write_handoff_terminal_restore(&mut restore, false);
+        write_handoff_terminal_restore(&mut restore, false, true);
         assert!(
             !restore
                 .windows(CHAT_KEYBOARD_ENHANCEMENT_PUSH.len())
@@ -1679,7 +1715,7 @@ mod tests {
         }
         let mut sink = FailingSink;
         // Must return normally (no panic) despite the write error.
-        write_handoff_terminal_restore(&mut sink, true);
+        write_handoff_terminal_restore(&mut sink, true, true);
     }
 
     // ── Interruptible reader (P0-A: bounded stop, no EOF dependency) ──────────

--- a/src/chat/state.rs
+++ b/src/chat/state.rs
@@ -348,6 +348,9 @@ pub struct UiState {
     /// P7c saved chat-session history picker. Distinct from the child-TUI
     /// Ctrl+G switcher.
     pub saved_session_picker: Option<crate::chat::session::SavedSessionPickerState>,
+    /// True while mouse capture is temporarily released for native terminal
+    /// drag selection.
+    pub mouse_selection_mode_active: bool,
 }
 
 /// 不可变 UI 快照（renderer 仅读，dispatcher 在 ui_dirty=true 时构造）.
@@ -416,6 +419,9 @@ pub struct UiSnapshot {
     pub slash_menu: Option<SlashMenuState>,
     /// P7c saved chat-session history picker overlay.
     pub saved_session_picker: Option<crate::chat::session::SavedSessionPickerState>,
+    /// True while mouse capture is temporarily released for native terminal
+    /// drag selection.
+    pub mouse_selection_mode_active: bool,
 }
 
 #[cfg(feature = "terminal-tui")]
@@ -451,6 +457,7 @@ impl UiSnapshot {
             switcher: None,
             slash_menu: None,
             saved_session_picker: None,
+            mouse_selection_mode_active: false,
         }
     }
 }
@@ -766,6 +773,7 @@ struct SnapshotDirtyFields {
     focus: crate::chat::sessions::FocusTarget,
     token_usage_summary: MainSessionTokenUsageSummary,
     main_queue_status: MainQueueStatus,
+    mouse_selection_mode_active: bool,
 }
 
 impl ChatState {
@@ -813,6 +821,7 @@ impl ChatState {
                 slash_menu: None,
                 at_path_candidates: Vec::new(),
                 saved_session_picker: None,
+                mouse_selection_mode_active: false,
             },
             stream: StreamState {
                 visible_drafts: Vec::new(),
@@ -905,6 +914,7 @@ impl ChatState {
             switcher: self.ui.switcher.clone(),
             slash_menu: self.ui.slash_menu.clone(),
             saved_session_picker: self.ui.saved_session_picker.clone(),
+            mouse_selection_mode_active: self.ui.mouse_selection_mode_active,
         }
     }
 
@@ -963,6 +973,7 @@ impl ChatState {
             focus: self.ui.focus,
             token_usage_summary: self.ui.token_usage_summary,
             main_queue_status: self.ui.main_queue_status,
+            mouse_selection_mode_active: self.ui.mouse_selection_mode_active,
         }
     }
 
@@ -1013,6 +1024,7 @@ impl ChatState {
                 self.ui.chat_mode = mode;
                 vec![Effect::RequestRedraw]
             }
+            Action::MouseSelectionModeChanged { active } => self.reduce_mouse_selection_mode_changed(active),
             Action::ModelChanged { model } => {
                 // BUG-07: /model <name> 在线切换。更新 session.model 让 status bar
                 // 立刻显示新 model；后续 LLM turn 真切 model 由主循环写 EffectDeps
@@ -1184,6 +1196,9 @@ impl ChatState {
         }
         if key.code == KeyCode::Char('d') && key.modifiers == KeyModifiers::CONTROL && self.ui.input.is_empty() {
             return vec![Effect::Quit];
+        }
+        if crate::chat::tui::is_mouse_selection_toggle_key(key) {
+            return vec![Effect::RequestRedraw];
         }
         if self.ui.saved_session_picker.is_some() {
             return self.reduce_saved_session_picker_key_pressed(key);
@@ -2971,6 +2986,16 @@ impl ChatState {
         vec![Effect::RequestRedraw]
     }
 
+    /// `Action::MouseSelectionModeChanged` — update the footer/status hint for
+    /// Ctrl+Space mouse-selection mode. Idempotent to avoid redraw churn.
+    fn reduce_mouse_selection_mode_changed(&mut self, active: bool) -> Vec<Effect> {
+        if self.ui.mouse_selection_mode_active == active {
+            return Vec::new();
+        }
+        self.ui.mouse_selection_mode_active = active;
+        vec![Effect::RequestRedraw]
+    }
+
     /// `Action::SwitcherOpened` (v1.1b) — open the Ctrl+G switcher overlay over
     /// the supplied session snapshot, highlighting the first row.
     fn reduce_switcher_opened(&mut self, entries: Vec<crate::chat::sessions::SwitcherEntry>) -> Vec<Effect> {
@@ -3297,6 +3322,8 @@ const fn ui_dirty_for(action: &Action) -> bool {
         Action::SlashCommandIssued { .. } => false,
         // 模式切换：status bar 显示 mode 字段.
         Action::ModeChanged(_) => true,
+        // Footer/status hint for temporary native terminal selection mode.
+        Action::MouseSelectionModeChanged { .. } => true,
         // BUG-07: 模型切换写 session.model，status bar 显示该字段 → dirty.
         Action::ModelChanged { .. } => true,
         // Bug #3: provider 切换写 session.provider（status bar 显示该字段）→ dirty.
@@ -9651,6 +9678,7 @@ mod tests {
             assert!(snap.conversation_lines.is_empty());
             assert_eq!(snap.turn_count, 0);
             assert!(snap.streaming.is_none());
+            assert!(!snap.mouse_selection_mode_active);
         }
 
         #[test]
@@ -9670,6 +9698,18 @@ mod tests {
                 Arc::strong_count(&snap.conversation_lines)
             );
             assert_eq!(snap2.revision, 1);
+        }
+
+        #[test]
+        fn mouse_selection_mode_action_flows_to_snapshot() {
+            let mut state = make_state();
+
+            let effects = state.reduce(Action::MouseSelectionModeChanged { active: true });
+            let snap = state.build_ui_snapshot(1);
+
+            assert!(effects.iter().any(|effect| matches!(effect, Effect::RequestRedraw)));
+            assert!(state.ui.mouse_selection_mode_active);
+            assert!(snap.mouse_selection_mode_active);
         }
 
         #[test]

--- a/src/chat/tui.rs
+++ b/src/chat/tui.rs
@@ -144,6 +144,9 @@ pub struct TuiState {
     pub token_usage_summary: MainSessionTokenUsageSummary,
     /// First half of the `Ctrl+X Ctrl+E` external-editor chord.
     pub external_editor_prefix_armed: bool,
+    /// True while Ctrl+Space has temporarily released mouse capture so the
+    /// terminal can do native drag selection.
+    pub mouse_selection_mode_active: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -703,6 +706,9 @@ pub enum KeyDispatch {
     ToolApprovalDecision { tool_id: String, approved: bool },
     /// P8: cycle the in-session chat mode via Shift+Tab.
     ModeChanged(ChatMode),
+    /// Toggle mouse-selection mode (`Ctrl+Space`) for users who opted into
+    /// TUI mouse capture.
+    ToggleMouseSelectionMode,
 }
 
 pub(crate) fn sync_slash_menu_for_sources(
@@ -1499,7 +1505,7 @@ pub fn build_transcript_view(
 ) -> crate::chat::sessions::ActiveSessionView {
     let (mut lines, truncated) = transcript_lines_from_conversation(conversation);
     if lines.is_empty() {
-        lines.push("(transcript is empty)".to_string());
+        lines.push("(transcript is empty - PageUp/Home view history; /help for copy/export)".to_string());
     }
     crate::chat::sessions::ActiveSessionView {
         seq: TRANSCRIPT_SESSION_SEQ,
@@ -1568,6 +1574,9 @@ pub fn dispatch_global_key(key: KeyEvent, state: &mut TuiState) -> KeyDispatch {
     }
     if key.code == KeyCode::Char('d') && key.modifiers == KeyModifiers::CONTROL && state.input.is_empty() {
         return KeyDispatch::Exit;
+    }
+    if is_mouse_selection_toggle_key(key) {
+        return KeyDispatch::ToggleMouseSelectionMode;
     }
     // P7c: the saved chat-session picker has top overlay priority. It is
     // distinct from the child-TUI Ctrl+G switcher and captures all keys while
@@ -1801,6 +1810,10 @@ pub fn dispatch_global_key(key: KeyEvent, state: &mut TuiState) -> KeyDispatch {
         InputOutcome::Consumed | InputOutcome::Unhandled => KeyDispatch::Consumed,
         InputOutcome::Ignored => KeyDispatch::Ignored,
     }
+}
+
+pub(crate) fn is_mouse_selection_toggle_key(key: KeyEvent) -> bool {
+    key.modifiers == KeyModifiers::CONTROL && matches!(key.code, KeyCode::Char(' ') | KeyCode::Null)
 }
 
 /// Resolve a key while the Ctrl+G session switcher overlay is open (v1.1b).
@@ -3139,6 +3152,7 @@ impl TuiState {
             context_window_tokens: None,
             token_usage_summary: MainSessionTokenUsageSummary::default(),
             external_editor_prefix_armed: false,
+            mouse_selection_mode_active: false,
         }
     }
 
@@ -3782,6 +3796,9 @@ pub trait BottomChromeView {
     fn slash_menu(&self) -> Option<&SlashMenuState>;
     /// Open saved chat-session picker overlay (P7c), or `None` when closed.
     fn saved_session_picker(&self) -> Option<&crate::chat::session::SavedSessionPickerState>;
+    /// True while mouse capture has been temporarily released for native
+    /// terminal drag selection.
+    fn mouse_selection_mode_active(&self) -> bool;
 }
 
 impl BottomChromeView for TuiState {
@@ -3854,6 +3871,9 @@ impl BottomChromeView for TuiState {
     fn saved_session_picker(&self) -> Option<&crate::chat::session::SavedSessionPickerState> {
         self.saved_session_picker.as_ref()
     }
+    fn mouse_selection_mode_active(&self) -> bool {
+        self.mouse_selection_mode_active
+    }
 }
 
 impl BottomChromeView for crate::chat::state::UiSnapshot {
@@ -3925,6 +3945,9 @@ impl BottomChromeView for crate::chat::state::UiSnapshot {
     }
     fn saved_session_picker(&self) -> Option<&crate::chat::session::SavedSessionPickerState> {
         self.saved_session_picker.as_ref()
+    }
+    fn mouse_selection_mode_active(&self) -> bool {
+        self.mouse_selection_mode_active
     }
 }
 
@@ -4113,7 +4136,7 @@ fn fullscreen_transcript_top_scroll<V: BottomChromeView + ?Sized>(
     }
     if lines.is_empty() {
         lines.push(Line::from(Span::styled(
-            "(transcript is empty)",
+            "(transcript is empty - PageUp/Home view history; /help for copy/export)",
             Style::default().fg(Color::DarkGray),
         )));
     }
@@ -4298,7 +4321,7 @@ fn render_fullscreen_transcript<V: BottomChromeView + ?Sized>(
     }
     if lines.is_empty() {
         lines.push(Line::from(Span::styled(
-            "(transcript is empty)",
+            "(transcript is empty - PageUp/Home view history; /help for copy/export)",
             Style::default().fg(Color::DarkGray),
         )));
     }
@@ -7130,23 +7153,27 @@ fn render_input<V: BottomChromeView + ?Sized>(frame: &mut Frame, area: Rect, sta
     }
 }
 
-fn footer_text(ascii: bool, show_session_hint: bool) -> String {
+fn footer_text(ascii: bool, show_session_hint: bool, mouse_selection_mode_active: bool) -> String {
     // Claude Code style: dim gray, middle-dot separators, action-oriented
     // hints rather than key/label pairs.
     // P6b2: Ctrl+G remains PRX's sessions switcher; Claude-style external
     // editor parity is available through the alternate Ctrl+X Ctrl+E chord.
     let sep = if ascii { " | " } else { " \u{00B7} " };
+    if mouse_selection_mode_active {
+        return format!(" selection mode: drag select/copy{sep}Ctrl+Space restore mouse ");
+    }
     let mut parts = Vec::from([
         if ascii {
             "Up/Down scroll"
         } else {
             "\u{2191}/\u{2193} scroll"
         },
+        "Home/PageUp history",
         "Ctrl+P/N history",
         "Ctrl+G sessions",
         "Ctrl+O transcript",
         "/copy latest",
-        "drag select/copy",
+        "--plain drag copy",
         "Shift+Enter newline",
         "Ctrl+X Ctrl+E edit",
         "Tab fold",
@@ -7158,8 +7185,15 @@ fn footer_text(ascii: bool, show_session_hint: bool) -> String {
     format!(" {} ", parts.join(sep))
 }
 
-fn render_footer(frame: &mut Frame, area: Rect, ascii: bool, show_session_hint: bool) {
-    let footer = Paragraph::new(footer_text(ascii, show_session_hint)).style(Style::default().fg(Color::DarkGray));
+fn render_footer(
+    frame: &mut Frame,
+    area: Rect,
+    ascii: bool,
+    show_session_hint: bool,
+    mouse_selection_mode_active: bool,
+) {
+    let footer = Paragraph::new(footer_text(ascii, show_session_hint, mouse_selection_mode_active))
+        .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(footer, area);
 }
 
@@ -7194,7 +7228,13 @@ fn render_fullscreen_footer<V: BottomChromeView + ?Sized>(
     if render_session_list_footer(frame, area, state) {
         return;
     }
-    render_footer(frame, area, state.ascii_fallback(), session_footer_has_sessions(state));
+    render_footer(
+        frame,
+        area,
+        state.ascii_fallback(),
+        session_footer_has_sessions(state),
+        state.mouse_selection_mode_active(),
+    );
 }
 
 /// Render a tool approval prompt.
@@ -9415,7 +9455,7 @@ mod tests {
         let rows = fullscreen_rows(&state, 90, 24, &mut scroll);
         let joined = rows.join("\n");
         assert!(
-            !joined.contains("/help"),
+            !rows.iter().any(|row| row.trim_start().starts_with("> /help")),
             "submitted slash command must not remain as bright input text: {joined}"
         );
     }
@@ -9808,6 +9848,25 @@ mod tests {
             _ => panic!("test: expected ToolResult at end"),
         };
         assert_eq!(folded_before, folded_after, "mid-edit Tab must not fold cards");
+    }
+
+    #[test]
+    fn ctrl_space_dispatches_mouse_selection_toggle_without_touching_input() {
+        let mut state = TuiState::new("p", "m");
+
+        let out = dispatch_global_key(key_mod(KeyCode::Char(' '), KeyModifiers::CONTROL), &mut state);
+
+        assert_eq!(out, KeyDispatch::ToggleMouseSelectionMode);
+        assert!(state.input.is_empty());
+    }
+
+    #[test]
+    fn ctrl_space_null_form_dispatches_mouse_selection_toggle() {
+        let mut state = TuiState::new("p", "m");
+
+        let out = dispatch_global_key(key_mod(KeyCode::Null, KeyModifiers::CONTROL), &mut state);
+
+        assert_eq!(out, KeyDispatch::ToggleMouseSelectionMode);
     }
 
     #[test]
@@ -11342,8 +11401,37 @@ mod tests {
             "session footer should expose horizontal session navigation: {rows:?}"
         );
         assert!(
-            footer_text(false, true).contains("←/→ session") && footer_text(false, true).contains("Ctrl+P/N history"),
+            footer_text(false, true, false).contains("←/→ session")
+                && footer_text(false, true, false).contains("Ctrl+P/N history"),
             "static footer text helper also includes the dynamic hint"
+        );
+    }
+
+    #[test]
+    fn footer_exposes_history_and_plain_copy_guidance() {
+        let footer = footer_text(false, false, false);
+
+        assert!(
+            footer.contains("Home/PageUp history"),
+            "footer should expose in-app history scrolling: {footer}"
+        );
+        assert!(
+            footer.contains("--plain drag copy"),
+            "footer should point native drag-copy users to plain mode: {footer}"
+        );
+    }
+
+    #[test]
+    fn footer_selection_mode_exposes_restore_key() {
+        let footer = footer_text(false, false, true);
+
+        assert!(
+            footer.contains("selection mode"),
+            "selection footer missing mode: {footer}"
+        );
+        assert!(
+            footer.contains("Ctrl+Space restore mouse"),
+            "selection footer missing restore key: {footer}"
         );
     }
 
@@ -11544,7 +11632,10 @@ mod tests {
             empty.kind,
             crate::chat::sessions::model::ManagedKind::Transcript.as_str()
         );
-        assert_eq!(empty.lines, vec!["(transcript is empty)".to_string()]);
+        assert_eq!(
+            empty.lines,
+            vec!["(transcript is empty - PageUp/Home view history; /help for copy/export)".to_string()]
+        );
 
         let long = ConversationLine::Assistant {
             content: (0..(TRANSCRIPT_MAX_LINES + 25))
@@ -12171,8 +12262,8 @@ mod tests {
             "footer should advertise /copy: {joined}"
         );
         assert!(
-            joined.contains("drag select/copy"),
-            "footer should advertise native selection: {joined}"
+            joined.contains("--plain") && joined.contains("drag copy"),
+            "footer should advertise plain-mode native selection: {joined}"
         );
     }
 
@@ -12459,8 +12550,12 @@ mod tests {
         let rows = fullscreen_rows(&state, 64, 18, &mut scroll);
 
         assert!(
-            rows.iter().any(|row| row.contains("(transcript is empty)")),
+            rows.iter().any(|row| row.contains("transcript is empty")),
             "empty transcript message rendered: {rows:?}"
+        );
+        assert!(
+            rows.iter().any(|row| row.contains("PageUp") && row.contains("/help")),
+            "empty transcript should guide history/copy discovery: {rows:?}"
         );
         assert!(
             rows.iter().any(|row| row.contains("PRX") && row.contains("mode:")),


### PR DESCRIPTION
## Summary

Addresses two user reports about `prx chat`: (1) history feels unviewable, and (2) clicking a line to copy doesn't work. Root-cause audit found the data is never truncated — the real issues are one deterministic bug plus discoverability. Ships **A+B+C**; `/copy` is intentionally not extended.

### B — Fix PTY-detach mouse regression (the actual bug)
`PtyHandoffGuard` used to **unconditionally** re-enable mouse capture when a full-screen PTY child (vim/less/htop) detached, ignoring the env gate. That stranded the session with mouse capture forced ON, killing the default terminal drag-select-to-copy. Now the restore path re-enables mouse capture **only when the session had it active** (`mouse_capture_active`); raw mode and bracketed paste are still restored unconditionally.

### A — Discoverability guidance
Footer, `/help`, and empty-transcript placeholders now surface:
- View full history: `Home` / `PageUp` / `Ctrl+O` (not the terminal scrollbar — alt-screen consumes it)
- Native scroll + cross-history drag-select copy: restart with `prx chat --plain` (or `PRX_TUI=0`)
- Copy/export: `/copy latest|N` (OSC52) and `/export md|json`

### C — Mouse-release toggle (for `PRX_TUI_ENABLE_MOUSE=1` users)
`Ctrl+Space` toggles a selection mode that releases mouse capture so native drag-select works, then restores it. No-op when mouse capture isn't configured. Default mouse posture stays OFF (kept intentionally, so copy works out of the box).

## Not doing (per decision)
- In-app keyboard line-selection copy — `--plain` already covers it.
- Extending `/copy` to arbitrary lines / user messages / tool output.

## Verification
Independently re-run on the branch (not trusting the implementer's self-report):
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings` — clean
- `cargo check` (default + `--no-default-features`) — clean
- `cargo test --bin prx --all-features` — **5501 passed / 0 failed / 7 ignored**
- `cargo audit`, `cargo deny check advisories/bans/licenses/sources` — all green (no new deps)
- Real PTY demo: detach with mouse OFF leaves zero mouse-enable escape sequences (`?1000/1002/1003/1006/1015h` all 0); `Ctrl+Space` toggles selection-mode footer and restores.
- A/B/C production call-chains confirmed wired end-to-end (not dead code / test-only).
- Post-rebase merged tree (on top of the file-edit-diff work) compiles clean.