### PR TITLE
ci: run Lint/Test on rust PRs (restore PR-stage test/clippy gate)

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -43,7 +43,7 @@ jobs:
     lint:
         name: Lint Gate (Format + Clippy + Strict Delta)
         needs: [changes]
-        if: needs.changes.outputs.rust_changed == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full'))
+        if: needs.changes.outputs.rust_changed == 'true'
         runs-on: ubuntu-latest
         timeout-minutes: 25
         steps:
@@ -71,7 +71,7 @@ jobs:
     test:
         name: Test
         needs: [changes, lint]
-        if: needs.changes.outputs.rust_changed == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full')) && needs.lint.result == 'success'
+        if: needs.changes.outputs.rust_changed == 'true' && needs.lint.result == 'success'
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
@@ -283,8 +283,8 @@ jobs:
                   fi
 
                   if [ "$event_name" = "pull_request" ]; then
-                    if [ "$build_result" != "success" ]; then
-                      echo "Required PR build job did not pass."
+                    if [ "$lint_result" != "success" ] || [ "$lint_strict_delta_result" != "success" ] || [ "$test_result" != "success" ] || [ "$build_result" != "success" ]; then
+                      echo "Required PR CI jobs did not pass."
                       exit 1
                     fi
                     echo "PR required checks passed."


### PR DESCRIPTION
## Problem

Rust PRs never ran `cargo test` / `fmt --check` / `clippy` at the PR stage. The `Lint Gate` and `Test` jobs were gated behind a `ci:full` label that **does not exist** in this repo, so on any pull request they skipped permanently. Only `Build (Smoke)` (compile-only) plus the security/license scans ran. Real test/lint enforcement was deferred to the post-merge push-to-`main` event — too late to block a bad PR. `CI Required Gate` compounded this by only checking `build_result` on PR events.

Net effect: code that breaks tests or fails fmt/clippy could merge to `main` without ever being tested in CI (recent merges relied entirely on local verification + manual review).

## Fix

- `lint` / `test` jobs: drop the `ci:full` label condition so they run on any rust-affecting PR, exactly like `Build (Smoke)` (`if: rust_changed == 'true'`).
- `CI Required Gate` (`ci-required`): its `pull_request` branch now requires `lint` + `test` + `build` success, not just `build`.

Out of scope (intentionally unchanged):
- Heavy jobs (Miri / Coverage / Mutants / Fuzz) stay schedule-only.
- `docs-quality` still carries the same `ci:full` gate — separate concern, left for a follow-up.

## Notes
- This PR edits a workflow file, so `Workflow Owner Approval` gates it — a workflow owner must approve before `CI Required Gate` passes.
- E2E validation of "Test now runs on rust PRs" happens after this merges: re-running CI on an open rust PR (e.g. #46) picks up the fixed workflow via the merge ref.
- Recommended follow-up (not in this PR): add branch protection on `main` requiring the `CI Required Gate` status check, so the gate is actually enforced at merge.